### PR TITLE
fix: Properly indicate lack of generateObject() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,30 @@ console.log(experimental_providerMetadata);
 - **For Pro/Max subscribers**: This is informational only - usage is covered by your monthly subscription
 - **For API key users**: This represents actual charges that will be billed to your account
 
+## Limitations
+
+### Object Generation Not Supported
+
+The Claude Code CLI does not support structured output or object generation. Attempting to use `generateObject()` or `streamObject()` will throw an error:
+
+```typescript
+import { generateObject } from 'ai';
+import { claudeCode } from 'ai-sdk-provider-claude-code';
+import { z } from 'zod';
+
+// This will throw UnsupportedFunctionalityError
+await generateObject({
+  model: claudeCode('sonnet'),
+  schema: z.object({
+    name: z.string(),
+    age: z.number(),
+  }),
+  prompt: 'Generate a person',
+});
+```
+
+This is a limitation of the Claude Code CLI interface, which doesn't provide JSON mode or structured output capabilities.
+
 ## Error Handling
 
 ```typescript

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model';
 import { ClaudeCodeCLI } from './claude-code-cli';
 import type { LanguageModelV1CallOptions } from '@ai-sdk/provider';
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 
 vi.mock('./claude-code-cli');
 
@@ -141,6 +142,39 @@ describe('ClaudeCodeLanguageModel', () => {
         expect.any(Object)
       );
     });
+
+    it('should throw error for object-json mode', async () => {
+      const options: LanguageModelV1CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] }],
+        mode: {
+          type: 'object-json',
+          schema: { type: 'object', properties: { name: { type: 'string' } } },
+        },
+        inputFormat: 'messages',
+      };
+
+      await expect(model.doGenerate(options)).rejects.toThrow(UnsupportedFunctionalityError);
+      await expect(model.doGenerate(options)).rejects.toThrow("'object-json mode' functionality not supported");
+    });
+
+    it('should throw error for object-tool mode', async () => {
+      const options: LanguageModelV1CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Use tool' }] }],
+        mode: {
+          type: 'object-tool',
+          tool: {
+            type: 'function',
+            name: 'getTool',
+            description: 'A test tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        inputFormat: 'messages',
+      };
+
+      await expect(model.doGenerate(options)).rejects.toThrow(UnsupportedFunctionalityError);
+      await expect(model.doGenerate(options)).rejects.toThrow("'object-tool mode' functionality not supported");
+    });
   });
 
   describe('doStream', () => {
@@ -215,6 +249,39 @@ describe('ClaudeCodeLanguageModel', () => {
       const reader = result.stream.getReader();
 
       await expect(reader.read()).rejects.toThrow('Stream error');
+    });
+
+    it('should throw error for object-json mode in streaming', async () => {
+      const options: LanguageModelV1CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] }],
+        mode: {
+          type: 'object-json',
+          schema: { type: 'object', properties: { name: { type: 'string' } } },
+        },
+        inputFormat: 'messages',
+      };
+
+      await expect(model.doStream(options)).rejects.toThrow(UnsupportedFunctionalityError);
+      await expect(model.doStream(options)).rejects.toThrow("'object-json mode' functionality not supported");
+    });
+
+    it('should throw error for object-tool mode in streaming', async () => {
+      const options: LanguageModelV1CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Use tool' }] }],
+        mode: {
+          type: 'object-tool',
+          tool: {
+            type: 'function',
+            name: 'getTool', 
+            description: 'A test tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        inputFormat: 'messages',
+      };
+
+      await expect(model.doStream(options)).rejects.toThrow(UnsupportedFunctionalityError);
+      await expect(model.doStream(options)).rejects.toThrow("'object-tool mode' functionality not supported");
     });
   });
 

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -7,6 +7,7 @@ import type {
   LanguageModelV1ProviderMetadata,
   LanguageModelV1Message,
 } from '@ai-sdk/provider';
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 import { ClaudeCodeCLI } from './claude-code-cli.js';
 import type { ClaudeCodeModelConfig } from './types.js';
 import { isAssistantEvent, isResultEvent, isSystemEvent, isErrorEvent } from './types.js';
@@ -14,7 +15,7 @@ import { ClaudeCodeError, isAuthenticationError } from './errors.js';
 
 export class ClaudeCodeLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = 'v1';
-  readonly defaultObjectGenerationMode = 'tool' as const;
+  readonly defaultObjectGenerationMode = undefined;
   readonly supportsImageUrls = false;
   readonly supportsStructuredOutputs = false;
 
@@ -50,7 +51,19 @@ export class ClaudeCodeLanguageModel implements LanguageModelV1 {
     warnings?: LanguageModelV1CallWarning[];
     providerMetadata?: LanguageModelV1ProviderMetadata;
   }> {
-    const { prompt } = options;
+    const { prompt, mode } = options;
+
+    // Check for unsupported object generation modes
+    if (mode.type === 'object-json') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'object-json mode',
+      });
+    }
+    if (mode.type === 'object-tool') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'object-tool mode',
+      });
+    }
 
     // Convert messages to a single prompt string
     const promptText = this.messagesToPrompt(prompt);
@@ -150,6 +163,18 @@ export class ClaudeCodeLanguageModel implements LanguageModelV1 {
     };
     warnings?: LanguageModelV1CallWarning[];
   }> {
+    // Check for unsupported object generation modes
+    if (options.mode.type === 'object-json') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'object-json mode',
+      });
+    }
+    if (options.mode.type === 'object-tool') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'object-tool mode',
+      });
+    }
+
     const promptText = this.messagesToPrompt(options.prompt);
     
     // Use our improved spawn CLI for true zero-latency streaming


### PR DESCRIPTION
# Pull Request: Fix generateObject() Support Declaration

## Description

This PR corrects the provider's declaration of object generation support to accurately reflect the Claude Code CLI's capabilities. The provider was incorrectly declaring support for object generation via the `'tool'` mode when the underlying CLI cannot provide this functionality.

### What Changed

1. **Changed `defaultObjectGenerationMode` from `'tool'` to `undefined`**
   - This correctly indicates that the provider does not support object generation
   - Aligns with AI SDK specifications for providers without this capability

2. **Added explicit error handling for object generation attempts**
   - Throws `UnsupportedFunctionalityError` when `generateObject()` or `streamObject()` is called
   - Provides clear error messages: `'object-json mode' functionality not supported` and `'object-tool mode' functionality not supported`
   - Implemented in both `doGenerate()` and `doStream()` methods

3. **Added comprehensive test coverage**
   - Tests verify that object-json mode throws the correct error
   - Tests verify that object-tool mode throws the correct error
   - Tests cover both streaming and non-streaming scenarios

4. **Updated documentation**
   - Added "Limitations" section to README
   - Clearly documents that object generation is not supported
   - Provides example showing the error users will encounter

### Why This Change Is Necessary

The Claude Code CLI does not support:
- **JSON mode**: No way to force Claude to output valid JSON without markdown formatting
- **Tool/function calling**: No support for tools with schema-based parameters
- **Grammar-guided generation**: No constraints on output format

Even with `--output-format json`, the CLI only provides JSON metadata about the response - Claude's actual output remains markdown-formatted text. This makes reliable object generation impossible.

### AI SDK Specification Support

According to the AI SDK specification in `language-model-v1.ts`:

```typescript
/**
Default object generation mode that should be used with this model when
no mode is specified. Should be the mode with the best results for this
model. `undefined` can be returned if object generation is not supported.

This is needed to generate the best objects possible w/o requiring the
user to explicitly specify the object generation mode.
 */
readonly defaultObjectGenerationMode: LanguageModelV1ObjectGenerationMode;
```

The type definition explicitly includes `undefined` as a valid value:

```typescript
export type LanguageModelV1ObjectGenerationMode = 'json' | 'tool' | undefined;
```

This confirms that `undefined` is the intended way to indicate lack of object generation support.

### Impact on Users

- **Breaking Change**: No, this is a bug fix that prevents runtime errors
- **User Experience**: Users will now receive a clear error message when attempting unsupported functionality
- **Migration**: No migration needed - users attempting object generation will need to use a different provider

### Testing

All tests pass:
- ✓ 31 tests passing
- ✓ Linting passes
- ✓ Type checking passes

### Related Issues

This addresses the question of whether `generateObject()` is supported and ensures the provider is fully compliant with AI SDK specifications for providers that don't support structured output.

### Future Considerations

We investigated whether MCP (Model Context Protocol) servers could enable structured output, but determined that:
- MCP tools are called BY the model, not a replacement FOR the model's output
- Claude still formats tool results as markdown
- True structured output would require CLI-level support

If the Claude Code CLI adds JSON mode or structured output support in the future, we can update the provider accordingly.