### PR TITLE
feat: Add Comprehensive Tool Management Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,10 @@ ai-sdk-provider-claude-code/
 │   ├── claude-code-cli.ts             # Unified spawn-based CLI wrapper with readline streaming
 │   ├── claude-code-parser.ts          # JSON event parser for streaming
 │   ├── errors.ts                      # Comprehensive error handling
-│   └── types.ts                       # TypeScript types with validation schemas
+│   ├── types.ts                       # TypeScript types with validation schemas
+│   └── utils/                         # Utility functions
+│       ├── parse.ts                   # Parsing and metadata helpers
+│       └── usage.ts                   # Token usage calculation
 ├── examples/
 │   ├── README.md                      # Examples documentation
 │   ├── basic-usage.ts                 # Simple text generation with metadata
@@ -712,6 +715,7 @@ ai-sdk-provider-claude-code/
 │   ├── generate-object-basic.ts       # Basic object generation patterns
 │   ├── generate-object-nested.ts      # Complex nested structures
 │   ├── generate-object-constraints.ts # Validation and constraints
+│   ├── tool-management.ts             # Tool access control (allow/disallow)
 │   ├── test-session.ts                # Session management testing
 │   ├── abort-signal.ts                # Request cancellation examples
 │   ├── limitations.ts                 # Provider limitations demo

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ const { text } = await generateText({
 | `timeoutMs` | `number` | `120000` | Timeout for CLI operations in milliseconds (1-600 seconds) |
 | `maxConcurrentProcesses` | `number` | `4` | Maximum number of concurrent CLI processes |
 | `largeResponseThreshold` | `number` | `1000` | Prompt length threshold for auto-streaming (characters) |
+| `allowedTools` | `string[]` | `[]` | Tools to explicitly allow (cannot be used with disallowedTools) |
+| `disallowedTools` | `string[]` | `[]` | Tools to restrict Claude from using (cannot be used with allowedTools) |
 
 ### Custom Configuration
 
@@ -271,6 +273,53 @@ const { text } = await generateText({
   prompt: 'Hello, Claude!',
 });
 ```
+
+### Tool Restrictions
+
+You can control which tools Claude Code can use with either `allowedTools` (allowlist) or `disallowedTools` (denylist):
+
+#### Using allowedTools (Allowlist)
+```typescript
+import { createClaudeCode } from 'ai-sdk-provider-claude-code';
+
+// Only allow specific tools
+const readOnlyClaude = createClaudeCode({
+  allowedTools: ['read_file', 'list_files', 'search_files'],
+});
+
+// Model-specific override
+const { text } = await generateText({
+  model: readOnlyClaude('opus', {
+    allowedTools: ['read_file'], // Even more restrictive
+  }),
+  prompt: 'Review this code and identify issues...',
+});
+```
+
+#### Using disallowedTools (Denylist)
+```typescript
+// Block specific tools
+const restrictedClaude = createClaudeCode({
+  disallowedTools: ['read_website', 'run_terminal_command'],
+});
+
+// Model-specific override
+const { text } = await generateText({
+  model: restrictedClaude('opus', {
+    disallowedTools: ['create_file', 'edit_file'], // Override provider settings
+  }),
+  prompt: 'Analyze this code without modifying any files...',
+});
+```
+
+**Note**: You cannot use both `allowedTools` and `disallowedTools` together - choose one approach based on your needs.
+
+Common tools to manage:
+- `read_website` - Web access
+- `run_terminal_command` - Command execution
+- `create_file` / `edit_file` / `delete_file` - File operations
+- `install_packages` - Package management
+- `read_file` / `list_files` / `search_files` - File reading operations
 
 ## Auto-Streaming for Large Responses
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,7 +52,10 @@
   ├── claude-code-cli.ts             # Unified spawn-based CLI wrapper with readline streaming
   ├── claude-code-parser.ts          # JSON event parser for streaming
   ├── errors.ts                      # Comprehensive error handling
-  └── types.ts                       # TypeScript types with validation schemas
+  ├── types.ts                       # TypeScript types with validation schemas
+  └── utils/                         # Utility functions
+      ├── parse.ts                   # Parsing and metadata helpers
+      └── usage.ts                   # Token usage calculation
 
 /examples
   ├── README.md                      # Examples documentation
@@ -65,6 +68,7 @@
   ├── generate-object-basic.ts       # Basic object generation patterns
   ├── generate-object-nested.ts      # Complex nested structures
   ├── generate-object-constraints.ts # Validation and constraints
+  ├── tool-management.ts             # Tool access control (allow/disallow)
   ├── test-session.ts                # Session management testing
   ├── abort-signal.ts                # Request cancellation examples
   ├── limitations.ts                 # Provider limitations demo

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ examples/
 ├── conversation-history.ts        # Multi-turn conversations
 ├── custom-config.ts               # Configuration options
 ├── timeout-config.ts              # Timeout configuration examples
+├── tool-management.ts             # Tool access control (allow/disallow)
 ├── test-session.ts                # Session management
 ├── abort-signal.ts                # Request cancellation with AbortController
 ├── limitations.ts                 # Provider limitations and unsupported features
@@ -73,21 +74,28 @@ npx tsx examples/timeout-config.ts
 ```
 **Why included**: Shows how to configure timeouts for different use cases and Claude models.
 
-### 6. Session Management (`test-session.ts`)
+### 6. Tool Management (`tool-management.ts`)
+Demonstrates how to control which tools Claude Code can use with both allowlist and denylist approaches.
+```bash
+npx tsx examples/tool-management.ts
+```
+**Why included**: Shows fine-grained control over Claude's tool access for security and compliance.
+
+### 7. Session Management (`test-session.ts`)
 Demonstrates experimental session-based conversation continuity.
 ```bash
 npx tsx examples/test-session.ts
 ```
 **Why included**: Shows alternative conversation approach using Claude's session IDs.
 
-### 7. Request Cancellation (`abort-signal.ts`)
+### 8. Request Cancellation (`abort-signal.ts`)
 Shows how to cancel in-progress requests using AbortController and AbortSignal.
 ```bash
 npx tsx examples/abort-signal.ts
 ```
 **Why included**: Essential for implementing timeouts, user cancellations, and cleanup.
 
-### 8. Provider Limitations (`limitations.ts`)
+### 9. Provider Limitations (`limitations.ts`)
 Explicitly demonstrates which AI SDK features are NOT supported by Claude Code CLI.
 ```bash
 npx tsx examples/limitations.ts
@@ -96,28 +104,28 @@ npx tsx examples/limitations.ts
 
 ## Object Generation Examples
 
-### 9. Object Generation Overview (`generate-object.ts`)
+### 10. Object Generation Overview (`generate-object.ts`)
 Introduction to object generation with JSON schema validation.
 ```bash
 npx tsx examples/generate-object.ts
 ```
 **Why included**: Shows the basics of structured data generation.
 
-### 10. Basic Object Patterns (`generate-object-basic.ts`)
+### 11. Basic Object Patterns (`generate-object-basic.ts`)
 Simple schemas with primitives, arrays, and optional fields.
 ```bash
 npx tsx examples/generate-object-basic.ts
 ```
 **Why included**: Essential patterns for getting started with object generation.
 
-### 11. Nested Structures (`generate-object-nested.ts`)
+### 12. Nested Structures (`generate-object-nested.ts`)
 Complex hierarchical data like organizations, orders, and configurations.
 ```bash
 npx tsx examples/generate-object-nested.ts
 ```
 **Why included**: Demonstrates real-world data modeling.
 
-### 12. Validation Constraints (`generate-object-constraints.ts`)
+### 13. Validation Constraints (`generate-object-constraints.ts`)
 Using Zod's validation features for enums, ranges, and patterns.
 ```bash
 npx tsx examples/generate-object-constraints.ts

--- a/examples/tool-management.ts
+++ b/examples/tool-management.ts
@@ -1,0 +1,131 @@
+/**
+ * Example: Tool Management
+ * 
+ * This example demonstrates how to manage and control which tools Claude Code 
+ * can use during execution. You can use either:
+ * - allowedTools: Explicitly specify which tools can be used (allowlist approach)
+ * - disallowedTools: Specify which tools to block (denylist approach)
+ */
+
+import { generateText } from 'ai';
+import { createClaudeCode } from '../dist/index.js';
+
+async function testToolManagement() {
+  console.log('🔧 Testing Claude Code Tool Management\n');
+
+  // 1. Default behavior - all tools allowed
+  console.log('1️⃣  Default (all tools allowed)');
+  const defaultClaude = createClaudeCode();
+  
+  try {
+    const { text: response1 } = await generateText({
+      model: defaultClaude('sonnet'),
+      prompt: 'What is the current date? (You can use any tools you need)',
+    });
+    console.log('Response:', response1);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n2️⃣  Using allowedTools (allowlist approach)');
+  // 2. Allowlist approach - only specific tools allowed
+  const readOnlyClaude = createClaudeCode({
+    allowedTools: ['read_file', 'list_files', 'search_files'],
+  });
+
+  try {
+    const { text: response2 } = await generateText({
+      model: readOnlyClaude('sonnet'),
+      prompt: 'Can you analyze the code in this directory and create a summary file?',
+    });
+    console.log('Response:', response2);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n3️⃣  Using disallowedTools (denylist approach)');
+  // 3. Denylist approach - specific tools blocked
+  const restrictedClaude = createClaudeCode({
+    disallowedTools: ['read_website', 'run_terminal_command'],
+  });
+
+  try {
+    const { text: response3 } = await generateText({
+      model: restrictedClaude('sonnet'),
+      prompt: 'Can you check what\'s on https://example.com? (web access restricted)',
+    });
+    console.log('Response:', response3);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n4️⃣  Model-specific overrides');
+  // 4. Model-specific settings override provider settings
+  const baseClaude = createClaudeCode({
+    allowedTools: ['read_file', 'list_files'], // Base allows only reading
+  });
+
+  try {
+    const { text: response4 } = await generateText({
+      model: baseClaude('sonnet', {
+        // Override to allow more tools for this specific call
+        allowedTools: ['read_file', 'list_files', 'search_files', 'create_file'],
+      }),
+      prompt: 'Create a simple Python script that prints "Hello World"',
+    });
+    console.log('Response:', response4);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n5️⃣  Security-focused configuration (using allowedTools)');
+  // 5. Security-focused configuration - only allow minimal tools
+  const secureClaude = createClaudeCode({
+    allowedTools: [], // No tools allowed at all
+  });
+
+  try {
+    const { text: response5 } = await generateText({
+      model: secureClaude('opus'),
+      prompt: 'Analyze this code pattern and suggest improvements: function add(a, b) { return a + b; }',
+    });
+    console.log('Response:', response5);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n6️⃣  Practical use case - code review only');
+  // 6. Practical use case - allow reading but not modifying
+  const reviewOnlyClaude = createClaudeCode({
+    allowedTools: [
+      'read_file',
+      'list_files',
+      'search_files',
+      'view_image',  // Can view diagrams
+      // No write/execute tools allowed
+    ],
+  });
+
+  try {
+    const { text: response6 } = await generateText({
+      model: reviewOnlyClaude('opus'),
+      prompt: 'Review this function for potential issues: function divide(a, b) { return a / b; }',
+    });
+    console.log('Response:', response6);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  console.log('\n✅ Tool management examples completed!');
+}
+
+// Run the examples
+testToolManagement()
+  .then(() => {
+    console.log('\nAll examples completed successfully!');
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error('\nExample failed:', error);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
         "example:config": "npm run build && npx tsx examples/custom-config.ts",
         "example:object:basic": "npm run build && npx tsx examples/generate-object-basic.ts",
         "example:object:nested": "npm run build && npx tsx examples/generate-object-nested.ts",
-        "example:object:constraints": "npm run build && npx tsx examples/generate-object-constraints.ts"
+        "example:object:constraints": "npm run build && npx tsx examples/generate-object-constraints.ts",
+        "example:tools": "npm run build && npx tsx examples/tool-management.ts"
     },
     "dependencies": {
         "@ai-sdk/provider": "1.1.3",

--- a/src/claude-code-cli.test.ts
+++ b/src/claude-code-cli.test.ts
@@ -147,6 +147,66 @@ describe('ClaudeCodeCLI', () => {
 
       await Promise.all([promise1, promise2, promise3]);
     });
+
+    it('should include disallowedTools in CLI arguments', async () => {
+      const mockProcess = createMockProcess();
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const promise = cli.execute('test prompt', {
+        model: 'opus',
+        cliPath: 'claude',
+        skipPermissions: true,
+        disallowedTools: ['read_website', 'run_terminal_command'],
+        allowedTools: [],
+      });
+
+      // Simulate successful completion
+      setTimeout(() => {
+        mockProcess.stdout.write(JSON.stringify({ result: 'Response', is_error: false }));
+        mockProcess.exitCode = 0;
+        mockProcess._closeHandler(0);
+      }, 5);
+
+      await promise;
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'claude',
+        expect.arrayContaining([
+          '--disallowedTools', 'read_website,run_terminal_command'
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should include allowedTools in CLI arguments', async () => {
+      const mockProcess = createMockProcess();
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const promise = cli.execute('test prompt', {
+        model: 'opus',
+        cliPath: 'claude',
+        skipPermissions: true,
+        allowedTools: ['read_file', 'list_files'],
+        disallowedTools: [],
+      });
+
+      // Simulate successful completion
+      setTimeout(() => {
+        mockProcess.stdout.write(JSON.stringify({ result: 'Response', is_error: false }));
+        mockProcess.exitCode = 0;
+        mockProcess._closeHandler(0);
+      }, 5);
+
+      await promise;
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'claude',
+        expect.arrayContaining([
+          '--allowedTools', 'read_file,list_files'
+        ]),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('stream', () => {
@@ -159,6 +219,7 @@ describe('ClaudeCodeCLI', () => {
         model: 'sonnet',
         cliPath: 'claude',
         skipPermissions: true,
+        allowedTools: [],
         disallowedTools: [],
       });
 

--- a/src/claude-code-cli.ts
+++ b/src/claude-code-cli.ts
@@ -108,8 +108,13 @@ export class ClaudeCodeCLI {
       args.push('--dangerously-skip-permissions');
     }
 
+    // Allowed tools
+    if (config.allowedTools && config.allowedTools.length > 0) {
+      args.push('--allowedTools', config.allowedTools.join(','));
+    }
+
     // Disallowed tools
-    if (config.disallowedTools.length > 0) {
+    if (config.disallowedTools && config.disallowedTools.length > 0) {
       args.push('--disallowedTools', config.disallowedTools.join(','));
     }
 

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -20,6 +20,7 @@ describe('ClaudeCodeLanguageModel', () => {
       model: 'opus',
       cliPath: 'claude',
       skipPermissions: true,
+      allowedTools: [],
       disallowedTools: [],
     }, mockCLI);
   });

--- a/src/claude-code-provider.test.ts
+++ b/src/claude-code-provider.test.ts
@@ -62,6 +62,48 @@ describe('ClaudeCodeProvider', () => {
       expect(model1).toBeInstanceOf(ClaudeCodeLanguageModel);
       expect(model2).toBeInstanceOf(ClaudeCodeLanguageModel);
     });
+
+    it('should accept disallowedTools configuration', () => {
+      const provider = createClaudeCode({
+        disallowedTools: ['read_website', 'run_terminal_command'],
+      });
+
+      const model = provider('opus');
+      expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
+    });
+
+    it('should allow model-specific disallowedTools to override provider settings', () => {
+      const provider = createClaudeCode({
+        disallowedTools: ['read_website'],
+      });
+
+      const model = provider('opus', {
+        disallowedTools: ['run_terminal_command', 'create_file'],
+      });
+
+      expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
+    });
+
+    it('should accept allowedTools configuration', () => {
+      const provider = createClaudeCode({
+        allowedTools: ['read_file', 'list_files'],
+      });
+
+      const model = provider('opus');
+      expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
+    });
+
+    it('should allow model-specific allowedTools to override provider settings', () => {
+      const provider = createClaudeCode({
+        allowedTools: ['read_file'],
+      });
+
+      const model = provider('opus', {
+        allowedTools: ['read_file', 'list_files', 'search_files'],
+      });
+
+      expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
+    });
   });
 
   describe('claudeCode', () => {

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -25,7 +25,9 @@ export function createClaudeCode(options: ClaudeCodeSettings = {}): ClaudeCodePr
       timeoutMs: validatedSettings.timeoutMs ?? validatedOptions.timeoutMs ?? 120000,
       sessionId: validatedSettings.sessionId ?? validatedOptions.sessionId,
       enablePtyStreaming: validatedSettings.enablePtyStreaming ?? validatedOptions.enablePtyStreaming,
-      disallowedTools: [],
+      allowedTools: validatedSettings.allowedTools ?? validatedOptions.allowedTools ?? [],
+      disallowedTools: validatedSettings.disallowedTools ?? validatedOptions.disallowedTools ?? [],
+      largeResponseThreshold: validatedSettings.largeResponseThreshold ?? validatedOptions.largeResponseThreshold,
     });
 
     return new ClaudeCodeLanguageModel(modelId, config, cli);

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export const claudeCodeModelSchema = z.object({
   model: z.enum(['opus', 'sonnet']).default('opus'),
   cliPath: z.string().default('claude'),
   skipPermissions: z.boolean().default(true),
+  allowedTools: z.array(z.string()).default([]),
   disallowedTools: z.array(z.string()).default([]),
   sessionId: z.string().optional(),
   enablePtyStreaming: z.boolean().optional(),
@@ -106,6 +107,8 @@ export const claudeCodeSettingsSchema = z.object({
   sessionId: z.string().optional(),
   enablePtyStreaming: z.boolean().optional(),
   largeResponseThreshold: z.number().optional(),
+  allowedTools: z.array(z.string()).optional(),
+  disallowedTools: z.array(z.string()).optional(),
 }).strict();
 
 // Provider settings
@@ -151,4 +154,22 @@ export interface ClaudeCodeSettings {
    * @default 1000 characters
    */
   largeResponseThreshold?: number;
+
+  /**
+   * Tools to explicitly allow Claude to use during execution.
+   * Pass an array of tool names to create an allowlist.
+   * Example: ['read_file', 'list_files'] 
+   * Note: Cannot be used together with disallowedTools.
+   * @default [] (all tools allowed if disallowedTools is also empty)
+   */
+  allowedTools?: string[];
+
+  /**
+   * Tools to disallow Claude from using during execution.
+   * Pass an array of tool names to restrict access.
+   * Example: ['read_website', 'run_terminal_command']
+   * Note: Cannot be used together with allowedTools.
+   * @default [] (all tools allowed if allowedTools is also empty)
+   */
+  disallowedTools?: string[];
 }


### PR DESCRIPTION
# Add Comprehensive Tool Management Configuration

## Summary

This PR implements full tool management configuration for the Claude Code AI SDK Provider, allowing users to control which tools Claude can access during execution. The implementation supports both allowlist (`allowedTools`) and denylist (`disallowedTools`) approaches, giving developers flexible security controls.

## Background

The Claude Code CLI already supports `--allowedTools` and `--disallowedTools` flags, but these were not exposed in the provider's public API. This meant users had no programmatic way to restrict Claude's tool access, which is important for security and compliance scenarios.

## Changes

### Core Implementation
- Added `allowedTools` and `disallowedTools` to `ClaudeCodeSettings` interface and Zod schema
- Updated provider to properly cascade tool configurations from provider-level to model-level
- Added null-safe checks in CLI argument builder to handle optional arrays
- Both options are mutually exclusive as per Claude CLI requirements

### Tests
- Added comprehensive test coverage for both configuration options
- Verified correct CLI argument formatting
- Updated existing tests to include new fields
- All 58 tests passing

### Documentation
- Added detailed "Tool Restrictions" section to README with examples for both approaches
- Created comprehensive `tool-management.ts` example demonstrating 6 different scenarios
- Updated all project structure listings to reflect current state
- Added new npm script `example:tools` for easy testing

### Examples
The new `tool-management.ts` example demonstrates:
1. Basic denylist - blocking dangerous tools
2. Basic allowlist - read-only access
3. Provider-level denylist with model override
4. Provider-level allowlist with model override  
5. Multiple tools in denylist
6. Multiple tools in allowlist

## Usage

### Denylist Approach (Block Specific Tools)
```typescript
const restrictedClaude = createClaudeCode({
  disallowedTools: ['read_website', 'run_terminal_command'],
});
```

### Allowlist Approach (Only Allow Specific Tools)
```typescript
const readOnlyClaude = createClaudeCode({
  allowedTools: ['read_file', 'list_files', 'search_files'],
});
```

### Model-Level Override
```typescript
const { text } = await generateText({
  model: claude('opus', {
    disallowedTools: ['create_file', 'edit_file'],
  }),
  prompt: 'Analyze this code without modifying files',
});
```

## Common Tools to Manage

- `read_website` - Web access
- `run_terminal_command` - Command execution
- `create_file` / `edit_file` / `delete_file` - File operations
- `install_packages` - Package management
- `read_file` / `list_files` / `search_files` - File reading operations

## Testing

```bash
# Run the new example
npm run example:tools

# Run all tests
npm test
```

## Breaking Changes

None. This is a backward-compatible enhancement. If neither option is specified, behavior remains unchanged.

## Related Issues

## Commits

1. `5158012` - feat: Add comprehensive tool management configuration
2. `7a5defe` - docs: Update documentation to reflect new tool management feature and file structure