### PR TITLE
fix: validate maxConcurrentProcesses to prevent deadlock

### DIFF
--- a/src/claude-code-provider.test.ts
+++ b/src/claude-code-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createClaudeCode, claudeCode } from './claude-code-provider';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model';
+import { z } from 'zod';
 
 describe('ClaudeCodeProvider', () => {
   describe('createClaudeCode', () => {
@@ -103,6 +104,56 @@ describe('ClaudeCodeProvider', () => {
       });
 
       expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
+    });
+
+    describe('validation', () => {
+      it('should reject maxConcurrentProcesses of 0', () => {
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 0,
+        })).toThrow(z.ZodError);
+      });
+
+      it('should reject negative maxConcurrentProcesses', () => {
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: -1,
+        })).toThrow(z.ZodError);
+      });
+
+      it('should reject non-integer maxConcurrentProcesses', () => {
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 2.5,
+        })).toThrow(z.ZodError);
+      });
+
+      it('should reject maxConcurrentProcesses over 100', () => {
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 101,
+        })).toThrow(z.ZodError);
+      });
+
+      it('should accept valid maxConcurrentProcesses values', () => {
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 1,
+        })).not.toThrow();
+
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 50,
+        })).not.toThrow();
+
+        expect(() => createClaudeCode({
+          maxConcurrentProcesses: 100,
+        })).not.toThrow();
+      });
+
+      it('should provide descriptive error for invalid maxConcurrentProcesses', () => {
+        try {
+          createClaudeCode({ maxConcurrentProcesses: 0 });
+        } catch (error) {
+          expect(error).toBeInstanceOf(z.ZodError);
+          const zodError = error as z.ZodError;
+          expect(zodError.errors[0].message).toBe('Number must be greater than or equal to 1');
+        }
+      });
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,7 @@ export type ClaudeCodeModelConfig = z.infer<typeof claudeCodeModelSchema>;
 export const claudeCodeSettingsSchema = z.object({
   cliPath: z.string().optional(),
   skipPermissions: z.boolean().optional(),
-  maxConcurrentProcesses: z.number().optional(),
+  maxConcurrentProcesses: z.number().int().min(1).max(100).optional(),
   timeoutMs: z.number().min(1000).max(600000).optional(),
   sessionId: z.string().optional(),
   enablePtyStreaming: z.boolean().optional(),
@@ -127,6 +127,7 @@ export interface ClaudeCodeSettings {
 
   /**
    * Maximum number of concurrent CLI processes
+   * Must be an integer between 1 and 100
    * @default 4
    */
   maxConcurrentProcesses?: number;


### PR DESCRIPTION
# Fix validation for maxConcurrentProcesses to prevent deadlock

## Summary

This PR adds validation to the `maxConcurrentProcesses` configuration option to prevent a deadlock scenario that occurs when the value is set to 0 or negative numbers.

## Problem

When `maxConcurrentProcesses` is set to 0 or a negative value, the CLI wrapper's queue management logic creates a deadlock:
- The condition `this.activeProcesses < this.maxProcesses` is never true when `maxProcesses` is 0 or negative
- All requests go into the queue but are never processed
- This causes requests to hang indefinitely

## Solution

Added Zod validation to ensure `maxConcurrentProcesses`:
- Must be an integer (not a decimal)
- Must be at least 1 
- Cannot exceed 100 (reasonable upper bound)

## Changes

### `src/types.ts`
- Updated `claudeCodeSettingsSchema` to validate `maxConcurrentProcesses` with `.int().min(1).max(100)`
- Updated JSDoc comment to document the constraints

### `src/claude-code-provider.test.ts`
- Added comprehensive test suite for validation:
  - Rejects 0, negative values, non-integers, and values over 100
  - Accepts valid values (1, 50, 100)
  - Verifies descriptive error messages

## Why not validate `largeResponseThreshold`?

After analyzing the codebase, I determined that `largeResponseThreshold` does **not** need validation:
- It's only used for comparison: `promptText.length > largeResponseThreshold`
- Edge cases are handled gracefully:
  - If 0 or negative: All prompts use streaming mode (harmless, just less efficient)
  - If very large: No prompts use streaming mode (also harmless)
- The code has fallback logic if streaming fails

## Testing

- ✅ All existing tests pass
- ✅ New validation tests pass
- ✅ Lint checks pass
- ✅ TypeScript type checks pass

## Breaking Changes

None. This is a protective validation that prevents invalid configurations that would have caused runtime failures.