### PR TITLE
fix: prevent misuse of provider factory with new keyword

### DIFF
--- a/src/claude-code-provider.test.ts
+++ b/src/claude-code-provider.test.ts
@@ -64,6 +64,15 @@ describe('ClaudeCodeProvider', () => {
       expect(model2).toBeInstanceOf(ClaudeCodeLanguageModel);
     });
 
+    it('should throw error when called with new keyword', () => {
+      const provider = createClaudeCode();
+      
+      expect(() => {
+        // @ts-expect-error - intentionally calling with new for testing
+        new provider('opus');
+      }).toThrow('The Claude Code model function cannot be called with the new keyword.');
+    });
+
     it('should accept disallowedTools configuration', () => {
       const provider = createClaudeCode({
         disallowedTools: ['read_website', 'run_terminal_command'],
@@ -167,6 +176,13 @@ describe('ClaudeCodeProvider', () => {
       const model = claudeCode('sonnet');
       expect(model).toBeInstanceOf(ClaudeCodeLanguageModel);
       expect(model.modelId).toBe('sonnet');
+    });
+
+    it('should throw error when default instance is called with new keyword', () => {
+      expect(() => {
+        // @ts-expect-error - intentionally calling with new for testing
+        new claudeCode('opus');
+      }).toThrow('The Claude Code model function cannot be called with the new keyword.');
     });
   });
 });

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -33,9 +33,20 @@ export function createClaudeCode(options: ClaudeCodeSettings = {}): ClaudeCodePr
     return new ClaudeCodeLanguageModel(modelId, config, cli);
   };
 
-  const provider = Object.assign(createModel, {
-    languageModel: createModel,
-  });
+  const provider = function (
+    modelId: 'opus' | 'sonnet',
+    settings?: ClaudeCodeSettings,
+  ) {
+    if (new.target) {
+      throw new Error(
+        'The Claude Code model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createModel(modelId, settings ?? {});
+  };
+
+  provider.languageModel = createModel;
 
   return provider as ClaudeCodeProvider;
 }


### PR DESCRIPTION
# Prevent misuse of provider factory with `new` keyword

## Summary

This PR adds a guard to prevent calling the Claude Code provider factory with the `new` keyword, aligning with conventions used by other official AI SDK providers.

## Problem

Without this guard, developers could accidentally write:
```typescript
const provider = new claudeCode('opus');
```

This would create unexpected behavior since the provider is designed to be called as a function, not instantiated as a class.

## Solution

- Added a `new.target` check that throws a descriptive error when the provider is called with `new`
- The error message matches the pattern used by other AI SDK providers
- Added comprehensive tests to verify the behavior

## Changes

- **src/claude-code-provider.ts**: Refactored provider factory to include `new.target` guard
- **src/claude-code-provider.test.ts**: Added tests for both factory and default instance

## Testing

All existing tests pass, plus new tests verify:
- ✅ `createClaudeCode()` throws when called with `new`
- ✅ Default `claudeCode` instance throws when called with `new`
- ✅ Normal usage patterns continue to work unchanged

## Alignment with AI SDK

This change brings the claude-code provider in line with other official providers:
- OpenAI provider: ✅ Has this guard
- Anthropic provider: ✅ Has this guard  
- Mistral provider: ✅ Has this guard
- Claude Code provider: ✅ Now has this guard

## Breaking Changes

None. This change only prevents incorrect usage that would have resulted in unexpected behavior.

## Related Issue

Addresses feedback from code review regarding API ergonomics and alignment with AI SDK conventions.