### PR TITLE
docs: update README to use ai-sdk-v4 npm tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-08-15
+
+### Changed
+- Updated to stable AI SDK v5 (from v5-beta)
+- Updated dependencies to stable versions:
+  - `@ai-sdk/provider`: 2.0.0
+  - `@ai-sdk/provider-utils`: 3.0.3
+  - `@anthropic-ai/claude-code`: 1.0.81
+  - `ai` (devDependency): 5.0.14
+- Changed to fixed versioning for dependencies for better stability
+- Removed beta references from documentation and package.json
+- Updated package description to reflect stable v5 support
+
 ## [1.0.0-beta.1] - 2025-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/status-beta-FF6700" alt="beta status">
-  <a href="https://www.npmjs.com/package/ai-sdk-provider-claude-code"><img src="https://img.shields.io/npm/v/ai-sdk-provider-claude-code/beta?color=00A79E" alt="npm beta version" /></a>
+  <img src="https://img.shields.io/badge/status-stable-00A79E" alt="stable status">
+  <a href="https://www.npmjs.com/package/ai-sdk-provider-claude-code"><img src="https://img.shields.io/npm/v/ai-sdk-provider-claude-code?color=00A79E" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/ai-sdk-provider-claude-code"><img src="https://img.shields.io/npm/unpacked-size/ai-sdk-provider-claude-code?color=00A79E" alt="install size" /></a>
   <a href="https://www.npmjs.com/package/ai-sdk-provider-claude-code"><img src="https://img.shields.io/npm/dy/ai-sdk-provider-claude-code.svg?color=00A79E" alt="npm downloads" /></a>
   <a href="https://nodejs.org/en/about/releases/"><img src="https://img.shields.io/badge/node-%3E%3D18-00A79E" alt="Node.js ≥ 18" /></a>
@@ -9,28 +9,29 @@
 
 # AI SDK Provider for Claude Code SDK
 
-> **Beta Release**: This is the v5-beta compatible version. For AI SDK v4 support, use version 0.2.x.
+> **Stable Release**: Version 1.x is now stable and compatible with AI SDK v5. For AI SDK v4 support, use the `v4` tag or version 0.2.x.
 
 **ai-sdk-provider-claude-code** lets you use Claude via the [Vercel AI SDK](https://sdk.vercel.ai/docs) through the official `@anthropic-ai/claude-code` SDK/CLI.
 
 ## Version Compatibility
 
-| Provider Version | AI SDK Version | Status | Branch |
-|-----------------|----------------|---------|---------|
-| 0.x | v4 | Stable | [`ai-sdk-v4`](https://github.com/ben-vargas/ai-sdk-provider-claude-code/tree/ai-sdk-v4) |
-| 1.x-beta | v5-beta | Beta | `main` |
+| Provider Version | AI SDK Version | NPM Tag | Status | Branch |
+|-----------------|----------------|---------|---------|--------|
+| 1.x | v5 | `latest` | Stable | `main` |
+| 0.x | v4 | `v4` | Maintenance | [`ai-sdk-v4`](https://github.com/ben-vargas/ai-sdk-provider-claude-code/tree/ai-sdk-v4) |
 
 ### Installing the Right Version
 
-**For AI SDK v4 (stable):**
+**For AI SDK v5 (recommended):**
 ```bash
-npm install ai-sdk-provider-claude-code@^0.2.2 ai@^4.3.16
+npm install ai-sdk-provider-claude-code ai
+# or explicitly: npm install ai-sdk-provider-claude-code@latest
 ```
 
-**For AI SDK v5-beta:**
+**For AI SDK v4 (legacy):**
 ```bash
-npm install ai-sdk-provider-claude-code@beta ai@beta
-```
+npm install ai-sdk-provider-claude-code@v4 ai@^4.3.16
+# or use specific version: npm install ai-sdk-provider-claude-code@^0.2.2
 
 ## Installation
 
@@ -42,11 +43,11 @@ claude login
 
 ### 2. Add the provider
 ```bash
-# For v5-beta
-npm install ai-sdk-provider-claude-code@beta ai@beta
+# For v5 (recommended)
+npm install ai-sdk-provider-claude-code ai
 
-# For v4 (stable)
-npm install ai-sdk-provider-claude-code@^0.2.2 ai@^4.3.16
+# For v4 (legacy)
+npm install ai-sdk-provider-claude-code@v4 ai@^4.3.16
 ```
 
 ## Disclaimer
@@ -61,7 +62,7 @@ Please ensure you have appropriate permissions and comply with all applicable te
 
 ## Quick Start
 
-### AI SDK v5-beta
+### AI SDK v5
 ```typescript
 import { streamText } from 'ai';
 import { claudeCode } from 'ai-sdk-provider-claude-code';
@@ -88,12 +89,12 @@ const { text } = await generateText({
 console.log(text);
 ```
 
-## Breaking Changes in v1.x-beta
+## Breaking Changes in v1.x
 
-See [Breaking Changes Guide](docs/ai-sdk-v5/V5_BREAKING_CHANGES.md) for details on migrating from v0.x to v1.x-beta.
+See [Breaking Changes Guide](docs/ai-sdk-v5/V5_BREAKING_CHANGES.md) for details on migrating from v0.x to v1.x.
 
 Key changes:
-- Requires AI SDK v5-beta
+- Requires AI SDK v5
 - New streaming API pattern
 - Updated token usage properties
 - Changed message types

--- a/docs/ai-sdk-v5/DEVELOPMENT-STATUS.md
+++ b/docs/ai-sdk-v5/DEVELOPMENT-STATUS.md
@@ -1,7 +1,7 @@
-# Community Provider Status Analysis (v5-beta)
+# Community Provider Status Analysis (v5)
 
 ## Overview
-This document analyzes the requirements for ai-sdk-provider-claude-code to achieve community provider status in the Vercel AI SDK v5-beta ecosystem.
+This document analyzes the requirements for ai-sdk-provider-claude-code to achieve community provider status in the Vercel AI SDK v5 ecosystem.
 
 ## Current Implementation Status
 
@@ -16,7 +16,7 @@ This document analyzes the requirements for ai-sdk-provider-claude-code to achie
 - **Error Handling**: Comprehensive error handling with authentication detection
 - **AbortSignal Support**: Standard AI SDK pattern for timeouts and cancellation
 
-#### v5-Beta Specific Features
+#### v5 Specific Features
 - **LanguageModelV2 Implementation**: Fully compliant with `specificationVersion: 'v2'`
 - **Stream-Start Event**: Properly emits initial stream event with warnings
 - **Token Usage Naming**: Uses v5 convention (inputTokens, outputTokens, totalTokens)
@@ -43,9 +43,9 @@ This document analyzes the requirements for ai-sdk-provider-claude-code to achie
 - **API Documentation**: Clear documentation of all configuration options
 - **Migration Guide**: Comprehensive v4 to v5 migration documentation
 
-### 🚀 Meeting AI SDK v5-Beta Standards
+### 🚀 Meeting AI SDK v5 Standards
 
-Based on analysis of official v5-beta providers, we now meet all requirements:
+Based on analysis of official v5 providers, we now meet all requirements:
 
 1. **Provider Pattern** ✅
    - Factory function with provider instance
@@ -94,7 +94,7 @@ ai-sdk-provider-claude-code/
 │   │   ├── GUIDE.md
 │   │   ├── TROUBLESHOOTING.md
 │   │   └── DEVELOPMENT-STATUS.md
-│   └── ai-sdk-v5/                        # v5-beta documentation
+│   └── ai-sdk-v5/                        # v5 documentation
 │       ├── GUIDE.md                      # v5-specific usage guide
 │       ├── TROUBLESHOOTING.md            # v5-specific troubleshooting
 │       ├── DEVELOPMENT-STATUS.md         # This document
@@ -126,7 +126,7 @@ ai-sdk-provider-claude-code/
 
 ## 🎯 Ready for Community Status
 
-The provider now meets all requirements for v5-beta community provider status:
+The provider now meets all requirements for v5 community provider status:
 
 ### Technical Requirements ✅
 - Implements LanguageModelV2 specification
@@ -155,7 +155,7 @@ The provider now meets all requirements for v5-beta community provider status:
 ## Version Strategy
 
 - **0.x versions**: AI SDK v4 compatibility (maintained on `ai-sdk-v4` branch)
-- **1.x-beta versions**: AI SDK v5-beta compatibility (maintained on `main` branch)
+- **1.x versions**: AI SDK v5 compatibility (maintained on `main` branch)
 
 ## Next Steps for Community Submission
 
@@ -165,29 +165,29 @@ The provider now meets all requirements for v5-beta community provider status:
    ```
 
 2. **Prepare MDX Documentation**
-   Create a documentation file following the v5-beta community provider format (see example below)
+   Create a documentation file following the v5 community provider format (see example below)
 
 3. **Submit PR to AI SDK Repository**
-   - Add provider to v5-beta community providers list
+   - Add provider to v5 community providers list
    - Include MDX documentation
    - Reference npm package with beta tag
 
-## Example Community Provider MDX (v5-beta)
+## Example Community Provider MDX (v5)
 
 ```mdx
 ---
-title: Claude Code (v5-beta)
+title: Claude Code (v5)
 description: Use Claude via the official Claude Code SDK with your Pro/Max subscription
 ---
 
-# Claude Code Provider (v5-beta)
+# Claude Code Provider (v5)
 
 [ben-vargas/ai-sdk-provider-claude-code](https://github.com/ben-vargas/ai-sdk-provider-claude-code) 
 is a community provider that uses the official [Claude Code SDK](https://www.npmjs.com/package/@anthropic-ai/claude-code) 
-to provide language model support for the AI SDK v5-beta.
+to provide language model support for the AI SDK v5.
 
 <Note type="warning">
-  This is the v5-beta compatible version. For AI SDK v4 support, use version 0.2.x.
+  This is the v5 compatible version. For AI SDK v4 support, use version 0.2.x.
 </Note>
 
 ## Setup
@@ -256,9 +256,9 @@ console.log(result.text);
   the Claude Code SDK.
 </Note>
 
-## v5-Beta Specific Features
+## v5 Specific Features
 
-This version includes full support for AI SDK v5-beta features:
+This version includes full support for AI SDK v5 features:
 
 - **New streaming API** with promise-based result objects
 - **Updated token usage** properties (inputTokens, outputTokens, totalTokens)

--- a/docs/ai-sdk-v5/GUIDE.md
+++ b/docs/ai-sdk-v5/GUIDE.md
@@ -1,4 +1,4 @@
-# Usage Guide (AI SDK v5-beta)
+# Usage Guide (AI SDK v5)
 
 ## Essential Examples
 
@@ -130,7 +130,7 @@ const response = await generateText({
 
 ---
 
-## Key Changes in v5-beta
+## Key Changes in v5
 
 ### Message Format
 In v5, user messages must have content as an array of parts:
@@ -858,7 +858,7 @@ ai-sdk-provider-claude-code/
 │   └── tool-management.ts             # Tool access control (allow/disallow)
 ├── docs/                              # Documentation
 │   ├── ai-sdk-v4/                     # v4-specific documentation
-│   └── ai-sdk-v5/                     # v5-beta documentation
+│   └── ai-sdk-v5/                     # v5 documentation
 │       ├── GUIDE.md                   # This guide
 │       ├── TROUBLESHOOTING.md         # Common issues and solutions
 │       ├── DEVELOPMENT-STATUS.md      # Development status
@@ -886,8 +886,8 @@ ai-sdk-provider-claude-code/
 
 Contributions are welcome! Please read our contributing guidelines before submitting a PR.
 
-**Beta Focus Areas:**
-- v5-beta compatibility improvements
+**Focus Areas:**
+- v5 compatibility improvements
 - Performance optimizations
 - Better error handling patterns
 - TypeScript type improvements

--- a/docs/ai-sdk-v5/TROUBLESHOOTING.md
+++ b/docs/ai-sdk-v5/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
-# Troubleshooting Guide (AI SDK v5-beta)
+# Troubleshooting Guide (AI SDK v5)
 
-This guide documents common issues and solutions for the Claude Code AI SDK Provider with v5-beta.
+This guide documents common issues and solutions for the Claude Code AI SDK Provider with v5.
 
 ## Common Issues
 

--- a/docs/ai-sdk-v5/V5_BREAKING_CHANGES.md
+++ b/docs/ai-sdk-v5/V5_BREAKING_CHANGES.md
@@ -1,10 +1,10 @@
-# Breaking Changes: V4 to V5-Beta Migration
+# Breaking Changes: V4 to V5 Migration
 
-This document outlines the breaking changes users will encounter when upgrading from v4 to v5-beta of the ai-sdk-provider-claude-code.
+This document outlines the breaking changes users will encounter when upgrading from v4 to v5 of the ai-sdk-provider-claude-code.
 
-⚠️ **IMPORTANT**: This is a complete breaking change. The v5-beta version of this provider ONLY works with AI SDK v5-beta. You cannot use:
-- v5-beta provider with AI SDK v4 ❌
-- v4 provider with AI SDK v5-beta ❌
+⚠️ **IMPORTANT**: This is a complete breaking change. The v5 version of this provider ONLY works with AI SDK v5. You cannot use:
+- v5 provider with AI SDK v4 ❌
+- v4 provider with AI SDK v5 ❌
 
 You must upgrade both together.
 
@@ -154,4 +154,4 @@ const response = await result.text;
 
 - All Claude Code SDK-specific limitations still apply (no temperature control, no output length limits, etc.)
 - TypeScript users will get compile-time errors for most breaking changes
-- This is a complete rewrite for v5-beta compatibility - no v4 compatibility is maintained
+- This is a complete rewrite for v5 compatibility - no v4 compatibility is maintained

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains curated examples demonstrating the most important features of the Claude Code AI SDK Provider. Each example serves a specific purpose and demonstrates a key pattern or capability.
 
-> **Note**: These examples are written for Vercel AI SDK v5-beta. If you're using AI SDK v4, please refer to the v4 branch.
+> **Note**: These examples are written for Vercel AI SDK v5. If you're using AI SDK v4, please refer to the v4 branch.
 
 ## Prerequisites
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "0.2.2",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-sdk-provider-claude-code",
-            "version": "0.2.2",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
-                "@ai-sdk/provider": "beta",
-                "@ai-sdk/provider-utils": "beta",
-                "@anthropic-ai/claude-code": "1.0.24",
+                "@ai-sdk/provider": "2.0.0",
+                "@ai-sdk/provider-utils": "3.0.3",
+                "@anthropic-ai/claude-code": "1.0.81",
                 "jsonc-parser": "^3.3.1"
             },
             "devDependencies": {
@@ -21,7 +21,7 @@
                 "@typescript-eslint/eslint-plugin": "8.34.0",
                 "@typescript-eslint/parser": "8.34.0",
                 "@vitest/coverage-v8": "^3.2.4",
-                "ai": "beta",
+                "ai": "5.0.14",
                 "eslint": "9.28.0",
                 "globals": "16.2.0",
                 "tsup": "8.5.0",
@@ -37,14 +37,14 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "1.0.0-beta.11",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.0-beta.11.tgz",
-            "integrity": "sha512-dnRUPzSLvp3xvIx6M4FIz4ht8dfL8JkPKwH+akj10im4zbxUii3c3TQ3BJLRdx2Gq/SeljE9H0dX7PDtVyIrbQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.6.tgz",
+            "integrity": "sha512-JuSj1MtTr4vw2VBBth4wlbciQnQIV0o1YV9qGLFA+r85nR5H+cJp3jaYE0nprqfzC9rYG8w9c6XGHB3SDKgcgA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0-beta.1",
-                "@ai-sdk/provider-utils": "3.0.0-beta.5"
+                "@ai-sdk/provider": "2.0.0",
+                "@ai-sdk/provider-utils": "3.0.3"
             },
             "engines": {
                 "node": ">=18"
@@ -54,9 +54,9 @@
             }
         },
         "node_modules/@ai-sdk/provider": {
-            "version": "2.0.0-beta.1",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-beta.1.tgz",
-            "integrity": "sha512-Z8SPncMtS3RsoXITmT7NVwrAq6M44dmw0DoUOYJqNNtCu8iMWuxB8Nxsoqpa0uEEy9R1V1ZThJAXTYgjTUxl3w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+            "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-schema": "^0.4.0"
@@ -66,12 +66,12 @@
             }
         },
         "node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0-beta.5.tgz",
-            "integrity": "sha512-4Dv/wiGZrvO6fI7P0yMLa4XZru0XW8LPibTObbkHBdweLUVGIze7aCfxxQeY44Uqcbl/h6/yBTkx2XmPtwf/Ow==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+            "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0-beta.1",
+                "@ai-sdk/provider": "2.0.0",
                 "@standard-schema/spec": "^1.0.0",
                 "eventsource-parser": "^3.0.3",
                 "zod-to-json-schema": "^3.24.1"
@@ -98,10 +98,9 @@
             }
         },
         "node_modules/@anthropic-ai/claude-code": {
-            "version": "1.0.24",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.24.tgz",
-            "integrity": "sha512-4S6ly2297ngNlto7IFZeEicS9u0yRDhocOzndWFovGBb+iUoEPKdZa/rhVk/tcyCADL6S+mMkiGQOlqFDrN3JQ==",
-            "hasInstallScript": true,
+            "version": "1.0.81",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.81.tgz",
+            "integrity": "sha512-kiRgAhQ2vuodkHDAZjuR0aaNchl9SZLq0QF46JKsOw0Ik1eyEN0tdsF++AV//Ub1j4iS1fGIrU10uE7aqFfKYw==",
             "license": "SEE LICENSE IN README.md",
             "bin": {
                 "claude": "cli.js"
@@ -1963,19 +1962,16 @@
             }
         },
         "node_modules/ai": {
-            "version": "5.0.0-beta.25",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.0-beta.25.tgz",
-            "integrity": "sha512-pbfFqtQvz7hiDw6TwUH75CK9FgrZFBsxqbW4yW0aqluHw3nRbhf0w1u2AMiYgvWMy8Xf8TkBbMtY4vyMc4neeA==",
+            "version": "5.0.14",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.14.tgz",
+            "integrity": "sha512-xiujFa879skB7YxGzbeHAxepsr6AEaWcHPXrc5a9MRM6p4WdVAwn6mGwVZkBnhqGfZtXFr4LUnU2ayvcjWp5ig==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "1.0.0-beta.11",
-                "@ai-sdk/provider": "2.0.0-beta.1",
-                "@ai-sdk/provider-utils": "3.0.0-beta.5",
+                "@ai-sdk/gateway": "1.0.6",
+                "@ai-sdk/provider": "2.0.0",
+                "@ai-sdk/provider-utils": "3.0.3",
                 "@opentelemetry/api": "1.9.0"
-            },
-            "bin": {
-                "ai": "dist/bin/ai.min.js"
             },
             "engines": {
                 "node": ">=18"
@@ -4284,18 +4280,6 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/vite-node/node_modules/@types/node": {
-            "version": "24.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~7.8.0"
-            }
-        },
         "node_modules/vite-node/node_modules/fdir": {
             "version": "6.4.6",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -4323,15 +4307,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
-        },
-        "node_modules/vite-node/node_modules/undici-types": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/vite-node/node_modules/vite": {
             "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.0.0-beta.1",
-    "description": "AI SDK v5-beta provider for Claude via Claude Code SDK (use Pro/Max subscription)",
+    "version": "1.0.1",
+    "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",
         "claude-code",
@@ -64,9 +64,9 @@
         "example:all": "npm run build && npm run example:basic && npm run example:streaming && npm run example:conversation && npm run example:config && npm run example:object:basic && npm run example:object:nested && npm run example:object:constraints && npm run example:tools && npm run example:timeout"
     },
     "dependencies": {
-        "@ai-sdk/provider": "beta",
-        "@ai-sdk/provider-utils": "beta",
-        "@anthropic-ai/claude-code": "1.0.24",
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3",
+        "@anthropic-ai/claude-code": "1.0.81",
         "jsonc-parser": "^3.3.1"
     },
     "devDependencies": {
@@ -76,7 +76,7 @@
         "@typescript-eslint/eslint-plugin": "8.34.0",
         "@typescript-eslint/parser": "8.34.0",
         "@vitest/coverage-v8": "^3.2.4",
-        "ai": "beta",
+        "ai": "5.0.14",
         "eslint": "9.28.0",
         "globals": "16.2.0",
         "tsup": "8.5.0",
@@ -91,7 +91,6 @@
         "node": ">=18"
     },
     "publishConfig": {
-        "access": "public",
-        "tag": "beta"
+        "access": "public"
     }
 }

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -175,20 +175,26 @@ describe('ClaudeCodeLanguageModel', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(4);
+      expect(chunks).toHaveLength(6);
       expect(chunks[0]).toMatchObject({
         type: 'stream-start',
         warnings: [],
       });
       expect(chunks[1]).toMatchObject({
-        type: 'text-delta',
-        delta: 'Hello',
+        type: 'text-start',
       });
       expect(chunks[2]).toMatchObject({
         type: 'text-delta',
-        delta: ', world!',
+        delta: 'Hello',
       });
       expect(chunks[3]).toMatchObject({
+        type: 'text-delta',
+        delta: ', world!',
+      });
+      expect(chunks[4]).toMatchObject({
+        type: 'text-end',
+      });
+      expect(chunks[5]).toMatchObject({
         type: 'finish',
         finishReason: 'stop',
         usage: {
@@ -245,7 +251,7 @@ describe('ClaudeCodeLanguageModel', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(3);
+      expect(chunks).toHaveLength(5);
       expect(chunks[0]).toMatchObject({
         type: 'stream-start',
         warnings: expect.arrayContaining([
@@ -256,10 +262,16 @@ describe('ClaudeCodeLanguageModel', () => {
         ]),
       });
       expect(chunks[1]).toMatchObject({
+        type: 'text-start',
+      });
+      expect(chunks[2]).toMatchObject({
         type: 'text-delta',
         delta: '{\n  "a": 1,\n  "b": 2\n}',
       });
-      expect(chunks[2]).toMatchObject({
+      expect(chunks[3]).toMatchObject({
+        type: 'text-end',
+      });
+      expect(chunks[4]).toMatchObject({
         type: 'finish',
         finishReason: 'stop',
         usage: {
@@ -327,17 +339,23 @@ describe('ClaudeCodeLanguageModel', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(3);
+      expect(chunks).toHaveLength(5);
       expect(chunks[0]).toMatchObject({
         type: 'stream-start',
         warnings: [],
       });
-      // When JSON is malformed, extractJson returns the original text
       expect(chunks[1]).toMatchObject({
+        type: 'text-start',
+      });
+      // When JSON is malformed, extractJson returns the original text
+      expect(chunks[2]).toMatchObject({
         type: 'text-delta',
         delta: 'Here is the JSON: {"a": 1, "b": invalid}',
       });
-      expect(chunks[2]).toMatchObject({
+      expect(chunks[3]).toMatchObject({
+        type: 'text-end',
+      });
+      expect(chunks[4]).toMatchObject({
         type: 'finish',
         finishReason: 'stop',
         usage: {


### PR DESCRIPTION
NPM doesn't allow 'v4' as a tag name since it looks like a semver range.

This PR updates all references in the README from `@v4` to `@ai-sdk-v4` to match the actual npm tag that was created.

Changes:
- Update npm tag in compatibility table
- Update installation instructions
- Update top notice

This ensures users can actually install the v4-compatible version using the correct tag.