### PR TITLE
feat: add Zod v3 and v4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-08-18
+
+### Added
+- Support for both Zod v3 and v4 (peer dependency now accepts `^3.0.0 || ^4.0.0`)
+- Compatibility layer for Zod API differences between versions
+
+### Fixed
+- Function schema validation now works with both Zod v3 and v4
+- Error handling supports both `error.errors` (v3) and `error.issues` (v4) formats
+- Updated `z.record()` calls to specify both key and value types for v4 compatibility
+- Improved URL validation hints in generate-object-constraints example
+- Removed non-existent test-session.ts from run-all-examples.sh script
+
 ## [1.0.1] - 2025-08-15
 
 ### Changed

--- a/examples/generate-object-constraints.ts
+++ b/examples/generate-object-constraints.ts
@@ -122,7 +122,8 @@ async function example3_stringPatterns() {
           .optional(),
         linkedin: z.string()
           .url()
-          .regex(/linkedin\.com\/in\//, 'LinkedIn profile URL')
+          .regex(/^https:\/\/(?:www\.)?linkedin\.com\/in\//, 'LinkedIn profile URL must start with https://linkedin.com/in/')
+          .describe('Full LinkedIn profile URL including https:// protocol')
           .optional(),
       }),
       preferences: z.object({
@@ -140,7 +141,7 @@ async function example3_stringPatterns() {
   const { object } = await generateObject({
     model: claudeCode('sonnet'),
     schema: userRegistrationSchema,
-    prompt: 'Generate a complete user registration for a software developer from San Francisco with GitHub and LinkedIn profiles.',
+    prompt: 'Generate a complete user registration for a software developer from San Francisco. Include GitHub username (just the username) and a complete LinkedIn profile URL like https://www.linkedin.com/in/johndoe-developer',
   });
 
   console.log('Generated registration:');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-sdk-provider-claude-code",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
@@ -33,7 +33,7 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "zod": "^3.0.0"
+                "zod": "^3.0.0 || ^4.0.0"
             }
         },
         "node_modules/@ai-sdk/gateway": {
@@ -81,6 +81,15 @@
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4"
+            }
+        },
+        "node_modules/@ai-sdk/provider-utils/node_modules/zod-to-json-schema": {
+            "version": "3.24.6",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.24.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4280,6 +4289,18 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/vite-node/node_modules/@types/node": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+            "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "undici-types": "~7.10.0"
+            }
+        },
         "node_modules/vite-node/node_modules/fdir": {
             "version": "6.4.6",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -4307,6 +4328,15 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/vite-node/node_modules/undici-types": {
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+            "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/vite-node/node_modules/vite": {
             "version": "7.0.5",
@@ -4763,15 +4793,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",
@@ -85,7 +85,7 @@
         "zod": "^3.25.76"
     },
     "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.0.0 || ^4.0.0"
     },
     "engines": {
         "node": ">=18"

--- a/run-all-examples.sh
+++ b/run-all-examples.sh
@@ -18,7 +18,6 @@ examples=(
   "long-running-tasks"
   "abort-signal"
   "check-cli"
-  "test-session"
   "integration-test"
   "limitations"
 )

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -38,7 +38,10 @@ describe('claudeCodeSettingsSchema', () => {
     const result = claudeCodeSettingsSchema.safeParse(settings);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.errors[0].message).toContain('greater than or equal to 1');
+      // Support both Zod v3 (errors) and v4 (issues)
+      const issues = (result.error as any).errors || result.error.issues;
+      // Support both v3 and v4 error message formats
+      expect(issues[0].message).toMatch(/greater than or equal to 1|Too small.*>=1/);
     }
   });
 


### PR DESCRIPTION
## Summary
- Adds support for both Zod v3 and v4 to resolve compatibility issues
- Fixes #33 

## Changes
- Updated peer dependencies to accept both `^3.0.0 || ^4.0.0`
- Modified validation.ts to handle API differences between Zod versions
- Fixed function schema validation using `z.any().refine()` for compatibility
- Added support for both error formats (v3 uses `errors`, v4 uses `issues`)
- Updated tests to work with both error message formats
- Improved example prompts for better URL validation
- Removed non-existent test-session.ts from run-all-examples.sh

## Testing
- ✅ All tests pass with Zod v3.25.76
- ✅ All tests pass with Zod v4.0.17
- ✅ All examples run successfully with both versions
- ✅ Type checking passes
- ✅ Linting passes

## Breaking Changes
None - this is backwards compatible

## Version
Bumped to v1.1.0 as this adds new feature support