### PR TITLE
fix(validation): add http transport

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -231,6 +231,18 @@ describe('validateSettings', () => {
     };
     expect(validateSettings(validSSE).valid).toBe(true);
 
+    // Valid HTTP server
+    const validHTTP = {
+      mcpServers: {
+        apiServer: {
+          type: 'http',
+          url: 'https://example.com/api',
+          headers: { 'Authorization': 'Bearer token' }
+        }
+      }
+    };
+    expect(validateSettings(validHTTP).valid).toBe(true);
+
     // Invalid - missing required fields
     const invalidMissingCommand = {
       mcpServers: {
@@ -255,6 +267,19 @@ describe('validateSettings', () => {
     const result2 = validateSettings(invalidSSEMissingUrl);
     expect(result2.valid).toBe(false);
     expect(result2.errors[0]).toContain('mcpServers');
+
+    // Invalid - HTTP missing url
+    const invalidHTTPMissingUrl = {
+      mcpServers: {
+        invalid: {
+          type: 'http',
+          headers: { 'test': 'value' }
+        }
+      }
+    };
+    const result3 = validateSettings(invalidHTTPMissingUrl);
+    expect(result3.valid).toBe(false);
+    expect(result3.errors[0]).toContain('mcpServers');
   });
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -58,6 +58,12 @@ export const claudeCodeSettingsSchema = z.object({
       type: z.literal('sse'),
       url: z.string(),
       headers: z.record(z.string(), z.string()).optional()
+    }),
+    // McpHttpServerConfig
+    z.object({
+      type: z.literal('http'),
+      url: z.string(),
+      headers: z.record(z.string(), z.string()).optional()
     })
   ])).optional(),
   verbose: z.boolean().optional(),


### PR DESCRIPTION
Adds missing http transport to claude code config validation

docs: https://docs.anthropic.com/en/docs/claude-code/mcp#option-3%3A-add-a-remote-http-server
