### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2025-08-25
+
+### Fixed
+- Added missing HTTP transport validation for MCP server configuration (#38)
+
 ## [1.1.0] - 2025-08-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-sdk-provider-claude-code",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",


### PR DESCRIPTION
## Release v1.1.1

This PR contains the version bump and changelog update for v1.1.1.

### Changes
- Bumped version from 1.1.0 to 1.1.1
- Updated CHANGELOG.md

### Fixed in this release
- Added missing HTTP transport validation for MCP server configuration (#38)

### Release checklist
- [ ] Merge this PR
- [ ] Create GitHub release from tag v1.1.1
- [ ] Publish to npm