### PR TITLE
fix(v4): add HTTP transport for MCP server configuration

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -228,6 +228,18 @@ describe('validateSettings', () => {
     };
     expect(validateSettings(validSSE).valid).toBe(true);
 
+    // Valid HTTP server
+    const validHTTP = {
+      mcpServers: {
+        apiServer: {
+          type: 'http',
+          url: 'https://example.com/api',
+          headers: { 'Authorization': 'Bearer token' }
+        }
+      }
+    };
+    expect(validateSettings(validHTTP).valid).toBe(true);
+
     // Invalid - missing required fields
     const invalidMissingCommand = {
       mcpServers: {
@@ -252,6 +264,19 @@ describe('validateSettings', () => {
     const result2 = validateSettings(invalidSSEMissingUrl);
     expect(result2.valid).toBe(false);
     expect(result2.errors[0]).toContain('mcpServers');
+
+    // Invalid - HTTP missing url
+    const invalidHTTPMissingUrl = {
+      mcpServers: {
+        invalid: {
+          type: 'http',
+          headers: { 'test': 'value' }
+        }
+      }
+    };
+    const result3 = validateSettings(invalidHTTPMissingUrl);
+    expect(result3.valid).toBe(false);
+    expect(result3.errors[0]).toContain('mcpServers');
   });
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -47,6 +47,12 @@ export const claudeCodeSettingsSchema = z.object({
       type: z.literal('sse'),
       url: z.string(),
       headers: z.record(z.string()).optional()
+    }),
+    // McpHttpServerConfig
+    z.object({
+      type: z.literal('http'),
+      url: z.string(),
+      headers: z.record(z.string()).optional()
     })
   ])).optional(),
   verbose: z.boolean().optional(),


### PR DESCRIPTION
## Description

This PR backports the HTTP transport validation fix from the main branch to the ai-sdk-v4 branch.

## Problem
The validation schema was missing support for the HTTP transport type in MCP (Model Context Protocol) server configuration, despite it being officially supported by Claude Code.

## Solution
- Added HTTP transport configuration to the validation schema
- Added comprehensive test coverage for HTTP server validation
- Mirrors the fix from PR #38 (main branch)

## Testing
- ✅ All tests pass (230 tests)
- ✅ TypeScript compilation successful
- ✅ Linting passes (only pre-existing warnings)
- ✅ Build successful

## References
- Main branch fix: #38
- Claude Code docs: https://docs.anthropic.com/en/docs/claude-code/mcp#option-3%3A-add-a-remote-http-server

This ensures users on AI SDK v4 can properly use HTTP transport for MCP servers.