### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2025-09-03
+
+### Fixed
+- Fixed `canUseTool` hanging issue when using streaming input by holding input stream open until Claude returns results (#43)
+
 ## [1.1.2] - 2025-08-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",


### PR DESCRIPTION
## Summary
- Bump version from 1.1.2 to 1.1.3
- Includes fix for `canUseTool` hanging issue when using streaming input (#43)

## Changes Included
- Fixed bug where `canUseTool` would hang if input stream closed prematurely
- Holds input stream open until Claude returns results

## Test Plan
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes