### PR TITLE
feat: add streaming image handling and file-based example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,19 @@ Key changes:
 - 🔧 Tool management (MCP servers, permissions)
  - 🧩 Callbacks (hooks, canUseTool)
 
+## Image Inputs (Streaming Only)
+
+- Enable streaming input (`streamingInput: 'always'` or provide `canUseTool`) before sending images.
+- Supported payloads: data URLs (`data:image/png;base64,...`), strings prefixed with `base64:<mediaType>,<data>`, or objects `{ data: '<base64>', mimeType: 'image/png' }`.
+- Remote HTTP(S) image URLs are ignored with the warning "Image URLs are not supported by this provider; supply base64/data URLs." (`supportsImageUrls` remains `false`).
+- When streaming input is disabled, image parts trigger the streaming prerequisite warning and are omitted from the request.
+- Use realistic image payloads—very small placeholders may result in the model asking for a different image.
+- `examples/images.ts` accepts a local image path and converts it to a data URL on the fly: `npx tsx examples/images.ts /absolute/path/to/image.png`.
+
 ## Limitations
 
 - Requires Node.js ≥ 18
-- No image support
+- Image inputs require streaming mode with base64/data URLs (remote fetch is not supported)
 - Some AI SDK parameters unsupported (temperature, maxTokens, etc.)
 - `canUseTool` requires streaming input at the SDK level (AsyncIterable prompt). This provider supports it via `streamingInput`: use `'auto'` (default when `canUseTool` is set) or `'always'`. See GUIDE for details.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,14 @@ npx tsx examples/streaming.ts
 ```
 **Key concepts**: Stream processing, chunk handling, real-time output
 
-### 3. Conversation History (`conversation-history.ts`)
+### 3. Images (`images.ts`)
+**Purpose**: Stream a prompt that includes a local image (PNG/JPG/GIF/WebP).
+```bash
+npx tsx examples/images.ts /absolute/path/to/image.png
+```
+**Key concepts**: Image data URLs, streaming prerequisite, multimodal prompts
+
+### 4. Conversation History (`conversation-history.ts`)
 **Purpose**: Show the correct way to maintain context across multiple messages.
 ```bash
 npx tsx examples/conversation-history.ts
@@ -47,28 +54,28 @@ npx tsx examples/conversation-history.ts
 
 ## Advanced Configuration
 
-### 4. Custom Config (`custom-config.ts`)
+### 5. Custom Config (`custom-config.ts`)
 **Purpose**: Demonstrate provider and model configuration options.
 ```bash
 npx tsx examples/custom-config.ts
 ```
 **Key concepts**: Provider settings, model overrides, tool restrictions, permission modes
 
-### 5. Tool Management (`tool-management.ts`)
+### 6. Tool Management (`tool-management.ts`)
 **Purpose**: Show fine-grained control over Claude's tool access for security.
 ```bash
 npx tsx examples/tool-management.ts
 ```
 **Key concepts**: Allow/deny lists, tool security, MCP server tools, built-in tools
 
-### 6. Long-Running Tasks (`long-running-tasks.ts`)
+### 7. Long-Running Tasks (`long-running-tasks.ts`)
 **Purpose**: Handle timeouts properly using AI SDK's AbortSignal pattern.
 ```bash
 npx tsx examples/long-running-tasks.ts
 ```
 **Key concepts**: Custom timeouts, graceful cancellation, retry logic, Opus 4's extended thinking
 
-### 7. Abort Signal (`abort-signal.ts`)
+### 8. Abort Signal (`abort-signal.ts`)
 **Purpose**: Implement user-initiated cancellations and cleanup.
 ```bash
 npx tsx examples/abort-signal.ts
@@ -77,28 +84,28 @@ npx tsx examples/abort-signal.ts
 
 ## Object Generation (Structured Output)
 
-### 8. Object Generation Overview (`generate-object.ts`)
+### 9. Object Generation Overview (`generate-object.ts`)
 **Purpose**: Advanced real-world examples of object generation.
 ```bash
 npx tsx examples/generate-object.ts
 ```
 **Key concepts**: Complex schemas, product analysis, free-form JSON, practical applications
 
-### 9. Object Generation Tutorial (`generate-object-basic.ts`)
+### 10. Object Generation Tutorial (`generate-object-basic.ts`)
 **Purpose**: Learn object generation step-by-step with progressively complex examples.
 ```bash
 npx tsx examples/generate-object-basic.ts
 ```
 **Key concepts**: Schema basics, progressive complexity, best practices, clear explanations
 
-### 10. Nested Structures (`generate-object-nested.ts`)
+### 11. Nested Structures (`generate-object-nested.ts`)
 **Purpose**: Generate complex, real-world data structures.
 ```bash
 npx tsx examples/generate-object-nested.ts
 ```
 **Key concepts**: Hierarchical data, recursive schemas, complex relationships
 
-### 11. Validation Constraints (`generate-object-constraints.ts`)
+### 12. Validation Constraints (`generate-object-constraints.ts`)
 **Purpose**: Enforce data quality with advanced validation rules.
 ```bash
 npx tsx examples/generate-object-constraints.ts
@@ -107,28 +114,28 @@ npx tsx examples/generate-object-constraints.ts
 
 ## Testing & Troubleshooting
 
-### 12. Integration Test (`integration-test.ts`)
+### 13. Integration Test (`integration-test.ts`)
 **Purpose**: Comprehensive test suite to verify your setup and all features.
 ```bash
 npx tsx examples/integration-test.ts
 ```
 **Key concepts**: Feature verification, error handling, test patterns
 
-### 13. Check CLI (`check-cli.ts`)
+### 14. Check CLI (`check-cli.ts`)
 **Purpose**: Troubleshooting tool to verify CLI installation and authentication.
 ```bash
 npx tsx examples/check-cli.ts
 ```
 **Key concepts**: Setup verification, error diagnosis, troubleshooting steps
 
-### 14. Limitations (`limitations.ts`)
+### 15. Limitations (`limitations.ts`)
 **Purpose**: Understand what AI SDK features are not supported by the CLI.
 ```bash
 npx tsx examples/limitations.ts
 ```
 **Key concepts**: Unsupported parameters, workarounds, provider constraints
 
-### 15. Session Test (`test-session.ts`)
+### 16. Session Test (`test-session.ts`)
 **Purpose**: Demonstrates message history pattern with comparison to sessionless approach.
 ```bash
 npx tsx examples/test-session.ts

--- a/examples/images.ts
+++ b/examples/images.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { extname, basename } from 'node:path';
+import { streamText } from 'ai';
+import { claudeCode } from '../dist/index.js';
+
+const SUPPORTED_EXTENSIONS: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+function toDataUrl(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  const mediaType = SUPPORTED_EXTENSIONS[ext];
+  if (!mediaType) {
+    throw new Error(`Unsupported image extension "${ext}". Supported: ${Object.keys(SUPPORTED_EXTENSIONS).join(', ')}`);
+  }
+
+  const contents = readFileSync(filePath);
+  const base64 = contents.toString('base64');
+  return `data:${mediaType};base64,${base64}`;
+}
+
+async function main() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: npx tsx examples/images.ts /absolute/path/to/image.(png|jpg|jpeg|gif|webp)');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dataUrl = toDataUrl(filePath);
+
+  const result = streamText({
+    model: claudeCode('sonnet', { streamingInput: 'always' }),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: `Describe the mood conveyed by "${basename(filePath)}" in one sentence.` },
+          { type: 'image', image: dataUrl },
+        ],
+      },
+    ],
+  });
+
+  process.stdout.write('Assistant: ');
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  process.stdout.write('\n');
+}
+
+main().catch(error => {
+  console.error('Error while streaming image prompt:', error);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.2",
+    "version": "1.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-sdk-provider-claude-code",
-            "version": "1.1.2",
+            "version": "1.1.4",
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",

--- a/src/convert-to-claude-code-messages.images.test.ts
+++ b/src/convert-to-claude-code-messages.images.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import type { CoreMessage } from 'ai';
+import { convertToClaudeCodeMessages } from './convert-to-claude-code-messages.js';
+
+describe('convertToClaudeCodeMessages (images)', () => {
+  it('includes data URL images in streaming content', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Here is a sample image.' },
+          { type: 'image', image: 'data:image/png;base64,aGVsbG8=' },
+        ],
+      },
+    ] as CoreMessage[];
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts).toHaveLength(2);
+    expect(result.streamingContentParts[0]).toEqual({ type: 'text', text: 'Human: Here is a sample image.' });
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'aGVsbG8=',
+      },
+    });
+  });
+
+  it('includes base64 images when mimeType is provided', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Inline base64 image.' },
+          { type: 'image', image: { data: 'AQID', mimeType: 'image/jpeg' } },
+        ],
+      },
+    ] as CoreMessage[];
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/jpeg',
+        data: 'AQID',
+      },
+    });
+  });
+
+  it('warns and skips HTTP image URLs', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Remote image' },
+          { type: 'image', image: 'https://example.com/image.png' },
+        ],
+      },
+    ] as CoreMessage[];
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.hasImageParts).toBe(false);
+    expect(result.warnings).toContain('Image URLs are not supported by this provider; supply base64/data URLs.');
+    expect(result.streamingContentParts).toHaveLength(1);
+  });
+
+  it('accepts file parts with image media type', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'File part image.' },
+          { type: 'file', mediaType: 'image/png', data: 'aGVsbG8=' },
+        ],
+      },
+    ] as CoreMessage[];
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'aGVsbG8=',
+      },
+    });
+  });
+});

--- a/src/convert-to-claude-code-messages.test.ts
+++ b/src/convert-to-claude-code-messages.test.ts
@@ -57,7 +57,7 @@ describe('convertToClaudeCodeMessages', () => {
     expect(result.messagesPrompt).toBe('Human: Hello\n, \nworld!');
   });
 
-  it('should return warning for image content but not throw', () => {
+  it('should return warning when image content cannot be converted', () => {
     const result = convertToClaudeCodeMessages([
       {
         role: 'user',
@@ -69,8 +69,9 @@ describe('convertToClaudeCodeMessages', () => {
     ] as CoreMessage[]);
     
     expect(result.warnings).toBeDefined();
-    expect(result.warnings).toContain('Claude Code SDK does not support image inputs. Images will be ignored.');
+    expect(result.warnings).toContain('Unable to convert image content; supply base64/data URLs.');
     expect(result.messagesPrompt).toBe('Human: Look at this:');
+    expect(result.hasImageParts).toBe(false);
   });
 
   it('should handle unknown content types gracefully', () => {


### PR DESCRIPTION
## Summary

Implements Deliverable 4 from `SDK_ENHANCEMENTS_IMP.md`, adding streaming-only image support to the Claude Code AI SDK provider:

- Parse AI SDK image/file parts (data URLs, explicit base64 strings, file objects) into the CLI’s `source: { type: 'base64', media_type, data }` payload.
- Forward images only when streaming input is active, emitting the Deliverable 1 warning otherwise.
- Expand unit coverage across message conversion and the language model to validate data URL, base64, file and warning behaviour.
- Provide a real-world streaming example (`examples/images.ts`) that accepts a local PNG/JPG/GIF/WebP path and converts it to a data URL on the fly.
- Document streaming prerequisites and usage in the README, AI SDK v5 guide, and examples README.
- Bump the provider to **1.1.4**.

## Testing

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npx tsx examples/images.ts /absolute/path/to/image.png`

## References

- Resolves #45
