### PR TITLE
feat: add tool streaming support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Provider code and utilities sit in `src/`; each module keeps a matching `*.test.ts` (for example, `src/claude-code-provider.ts`).
+- Executable samples live in `examples/`; rebuild first, then run with `npx tsx ...` to exercise streaming or tool flows.
+- Long-form docs and migration notes are under `docs/ai-sdk-v5/` and `docs/ai-sdk-v4/`; touch both when behavior diverges, and ignore generated `dist/` artifacts.
+
+## Build, Test, and Development Commands
+- `npm run build` → `tsup` build for CJS/ESM bundles.
+- `npm run dev` → watch mode for rapid iterations.
+- `npm run lint` / `npm run typecheck` → ESLint plus `tsc --noEmit` to keep APIs strict.
+- `npm run test` (or `:node` / `:edge`) → Vitest suites per runtime; include `npm run test:integration` before publishing.
+- `npm run example:streaming` (or `run-all-examples.sh`) → smoke-test streaming tools described in `TOOL_STREAMING.md`.
+
+## Coding Style & Naming Conventions
+- 2-space indentation, `const` first, and no implicit `any`; ESLint enforces the ruleset and only relaxes the constraint inside tests.
+- File names stay kebab-case, exports are named, and TypeScript types/interfaces remain PascalCase.
+- Factor shared behaviors into helpers like `mcp-helpers.ts` or `logger.ts` instead of duplicating logic.
+
+## Testing Guidelines
+- Keep tests beside the module (`foo.ts` ↔ `foo.test.ts`) and mirror the API surface you touch.
+- Exercise Node and edge shim paths with `npm run test:node` and `npm run test:edge`; add scenario coverage in `examples/` when reproducing tool or streaming regressions.
+- Run `npx vitest run --coverage` (V8) before tagging a release and address drops introduced by new branches.
+
+## Commit & Pull Request Guidelines
+- Use conventional commits (`feat:`, `fix(scope):`, `chore:`) as in the log; reserve breaking changes for the body with a clear callout.
+- Reference issues with `#NN`, list the commands you ran, and include relevant screenshots or CLI transcripts when workflows change.
+- Update companion docs (`README.md`, `TOOL_STREAMING.md`, `docs/ai-sdk-v5/GUIDE.md`) in the same PR whenever behavior or configuration shifts.
+
+## Security & Configuration Tips
+- Authenticate locally via `claude login` before running examples and never commit CLI state; expose new options through `src/types.ts` with well-documented defaults.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Key changes:
 - **[Breaking Changes](docs/ai-sdk-v5/V5_BREAKING_CHANGES.md)** - v0.x to v1.x migration guide
 - **[Troubleshooting](docs/ai-sdk-v5/TROUBLESHOOTING.md)** - Common issues and solutions
 - **[Examples](examples/)** - Sample scripts and patterns
+ - **[Tool Streaming Support](docs/ai-sdk-v5/TOOL_STREAMING_SUPPORT.md)** - Event semantics and performance notes
 
 ## Core Features
 
@@ -136,6 +137,12 @@ Key changes:
 - Image inputs require streaming mode with base64/data URLs (remote fetch is not supported)
 - Some AI SDK parameters unsupported (temperature, maxTokens, etc.)
 - `canUseTool` requires streaming input at the SDK level (AsyncIterable prompt). This provider supports it via `streamingInput`: use `'auto'` (default when `canUseTool` is set) or `'always'`. See GUIDE for details.
+
+## Tool Error Parity (Streaming)
+
+- In addition to `tool-call` and `tool-result`, this provider emits a distinct `tool-error` stream event when a tool execution fails.
+- For parity with other tool events, `tool-error` includes `providerExecuted: true` and `providerMetadata['claude-code']` (e.g., `rawError`). These fields are documented extensions; downstream consumers may safely ignore them if unused.
+- See Tool Streaming Support for full event list, ordering guarantees, and performance considerations.
 
 ## Contributing
 

--- a/docs/ai-sdk-v5/GUIDE.md
+++ b/docs/ai-sdk-v5/GUIDE.md
@@ -173,6 +173,16 @@ Token usage properties have been renamed:
 
 ## Detailed Configuration
 
+## Performance and Limitations
+
+The provider optimizes tool streaming with pragmatic thresholds:
+
+- Delta streaming: Only for tool inputs ≤ 10KB and for prefix-only updates (appends). Non-prefix or large updates skip deltas and are captured in the final `tool-call` payload.
+- Size limits: Tool inputs exceeding 1MB throw an error; inputs above 100KB log a warning due to potential performance impact.
+- Memory: Tool state is retained until stream completion to prevent duplicate `tool-call` emissions for multi-chunk results or errors.
+
+See Tool Streaming Support for details and event semantics: docs/ai-sdk-v5/TOOL_STREAMING_SUPPORT.md#performance-considerations
+
 ### AbortSignal Support
 
 The provider fully supports the standard AbortSignal for request cancellation, following Vercel AI SDK patterns:

--- a/docs/ai-sdk-v5/TOOL_STREAMING_SUPPORT.md
+++ b/docs/ai-sdk-v5/TOOL_STREAMING_SUPPORT.md
@@ -1,0 +1,37 @@
+# Tool Streaming Support (AI SDK v5)
+
+## Overview
+Claude Code now emits full tool streaming events when used through the AI SDK v5 provider. This aligns the provider with the AI SDK's `LanguageModelV2StreamPart` contract, enabling downstream UIs to surface tool calls, inputs, and results in real time.
+
+## Requirements
+- **Streaming input enabled**: set `streamingInput: 'always'` or rely on `'auto'` by supplying `canUseTool`.
+- **Provider-executed tools**: Claude Code's built-in tools run inside the CLI; for every `tool-call` and `tool-result` event the provider sets `providerExecuted: true` so the AI SDK will not attempt to re-run the tool client-side.
+- **Claude Code CLI**: authenticate with `claude login` and ensure the CLI is on your PATH before running streaming examples or tests. Allow the built-in tools explicitly (for example `allowedTools: ['Bash', 'Read']`) or set a permissive permission mode such as `bypassPermissions`.
+
+## Stream Parts Emitted
+| Event | Description |
+|-------|-------------|
+| `tool-input-start` | Sent once per tool use with Claude's tool name and a stable ID. |
+| `tool-input-delta` | JSON-serialized arguments. The provider sends cumulative deltas; if Claude resends the full payload, the delta mirrors that payload. |
+| `tool-input-end` | Marks completion of the request payload going to the tool. |
+| `tool-call` | Includes `toolCallId`, `toolName`, serialized `input`, and `providerExecuted: true`. Raw, non-serialized input is preserved in `providerMetadata['claude-code'].rawInput`. |
+| `tool-result` | Streams the CLI output (JSON parsed when possible) with `toolName`, `toolCallId`, `isError`, `providerExecuted: true`, and the original output under `providerMetadata['claude-code'].rawResult`. |
+
+Text streaming (`text-start`/`text-delta`/`text-end`), response metadata, and finish parts continue to behave as before.
+
+## Usage Example
+Run the new example to observe the events:
+```bash
+npm run build
+npx tsx examples/tool-streaming.ts
+```
+The script approves tools via `canUseTool` and logs each event in order, demonstrating directory listing and file-read operations executed by the CLI.
+
+## Testing & Validation
+- Vitest suite includes coverage that asserts tool stream parts surface for provider-executed tools (`src/claude-code-language-model.test.ts`).
+- Integration and example scripts rely on the compiled `dist` build; run `npm run build && npm run test` before publishing.
+- If stream parts stop appearing, re-run with `DEBUG=1` or enable a custom logger (`settings.logger`) to capture warnings from the underlying SDK.
+
+## Known Limitations
+- Claude Code does not emit incremental tool argument chunks today; the provider emits a single `tool-input-delta` payload per tool call unless the SDK starts sending partial updates.
+- Remote image URLs remain unsupported; convert images to base64 data URLs and set `streamingInput` accordingly.

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,14 +38,21 @@ npx tsx examples/streaming.ts
 ```
 **Key concepts**: Stream processing, chunk handling, real-time output
 
-### 3. Images (`images.ts`)
+### 3. Tool Streaming (`tool-streaming.ts`)
+**Purpose**: Observe tool-call events emitted by the provider while Claude Code executes built-in tools.
+```bash
+npx tsx examples/tool-streaming.ts
+```
+**Key concepts**: Tool streaming, provider-executed tools, detailed stream inspection
+
+### 4. Images (`images.ts`)
 **Purpose**: Stream a prompt that includes a local image (PNG/JPG/GIF/WebP).
 ```bash
 npx tsx examples/images.ts /absolute/path/to/image.png
 ```
 **Key concepts**: Image data URLs, streaming prerequisite, multimodal prompts
 
-### 4. Conversation History (`conversation-history.ts`)
+### 5. Conversation History (`conversation-history.ts`)
 **Purpose**: Show the correct way to maintain context across multiple messages.
 ```bash
 npx tsx examples/conversation-history.ts
@@ -54,28 +61,28 @@ npx tsx examples/conversation-history.ts
 
 ## Advanced Configuration
 
-### 5. Custom Config (`custom-config.ts`)
+### 6. Custom Config (`custom-config.ts`)
 **Purpose**: Demonstrate provider and model configuration options.
 ```bash
 npx tsx examples/custom-config.ts
 ```
 **Key concepts**: Provider settings, model overrides, tool restrictions, permission modes
 
-### 6. Tool Management (`tool-management.ts`)
+### 7. Tool Management (`tool-management.ts`)
 **Purpose**: Show fine-grained control over Claude's tool access for security.
 ```bash
 npx tsx examples/tool-management.ts
 ```
 **Key concepts**: Allow/deny lists, tool security, MCP server tools, built-in tools
 
-### 7. Long-Running Tasks (`long-running-tasks.ts`)
+### 8. Long-Running Tasks (`long-running-tasks.ts`)
 **Purpose**: Handle timeouts properly using AI SDK's AbortSignal pattern.
 ```bash
 npx tsx examples/long-running-tasks.ts
 ```
 **Key concepts**: Custom timeouts, graceful cancellation, retry logic, Opus 4's extended thinking
 
-### 8. Abort Signal (`abort-signal.ts`)
+### 9. Abort Signal (`abort-signal.ts`)
 **Purpose**: Implement user-initiated cancellations and cleanup.
 ```bash
 npx tsx examples/abort-signal.ts
@@ -84,28 +91,28 @@ npx tsx examples/abort-signal.ts
 
 ## Object Generation (Structured Output)
 
-### 9. Object Generation Overview (`generate-object.ts`)
+### 10. Object Generation Overview (`generate-object.ts`)
 **Purpose**: Advanced real-world examples of object generation.
 ```bash
 npx tsx examples/generate-object.ts
 ```
 **Key concepts**: Complex schemas, product analysis, free-form JSON, practical applications
 
-### 10. Object Generation Tutorial (`generate-object-basic.ts`)
+### 11. Object Generation Tutorial (`generate-object-basic.ts`)
 **Purpose**: Learn object generation step-by-step with progressively complex examples.
 ```bash
 npx tsx examples/generate-object-basic.ts
 ```
 **Key concepts**: Schema basics, progressive complexity, best practices, clear explanations
 
-### 11. Nested Structures (`generate-object-nested.ts`)
+### 12. Nested Structures (`generate-object-nested.ts`)
 **Purpose**: Generate complex, real-world data structures.
 ```bash
 npx tsx examples/generate-object-nested.ts
 ```
 **Key concepts**: Hierarchical data, recursive schemas, complex relationships
 
-### 12. Validation Constraints (`generate-object-constraints.ts`)
+### 13. Validation Constraints (`generate-object-constraints.ts`)
 **Purpose**: Enforce data quality with advanced validation rules.
 ```bash
 npx tsx examples/generate-object-constraints.ts
@@ -114,28 +121,28 @@ npx tsx examples/generate-object-constraints.ts
 
 ## Testing & Troubleshooting
 
-### 13. Integration Test (`integration-test.ts`)
+### 14. Integration Test (`integration-test.ts`)
 **Purpose**: Comprehensive test suite to verify your setup and all features.
 ```bash
 npx tsx examples/integration-test.ts
 ```
 **Key concepts**: Feature verification, error handling, test patterns
 
-### 14. Check CLI (`check-cli.ts`)
+### 15. Check CLI (`check-cli.ts`)
 **Purpose**: Troubleshooting tool to verify CLI installation and authentication.
 ```bash
 npx tsx examples/check-cli.ts
 ```
 **Key concepts**: Setup verification, error diagnosis, troubleshooting steps
 
-### 15. Limitations (`limitations.ts`)
+### 16. Limitations (`limitations.ts`)
 **Purpose**: Understand what AI SDK features are not supported by the CLI.
 ```bash
 npx tsx examples/limitations.ts
 ```
 **Key concepts**: Unsupported parameters, workarounds, provider constraints
 
-### 16. Session Test (`test-session.ts`)
+### 17. Session Test (`test-session.ts`)
 **Purpose**: Demonstrates message history pattern with comparison to sessionless approach.
 ```bash
 npx tsx examples/test-session.ts

--- a/examples/integration-test.ts
+++ b/examples/integration-test.ts
@@ -59,33 +59,33 @@ async function testConversation() {
     const { text: response1 } = await generateText({
       model: claudeCode('sonnet'),
       messages: [
-        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Remember this.' },
+        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Just acknowledge this information.' },
       ],
     });
     console.log('✅ First turn:', response1);
-    
+
     // Second turn: test memory with full history
     const { text: response2 } = await generateText({
       model: claudeCode('sonnet'),
       messages: [
-        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Remember this.' },
+        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Just acknowledge this information.' },
         { role: 'assistant', content: response1 },
         { role: 'user', content: 'What is my favorite color?' },
       ],
     });
-    
+
     if (response2.toLowerCase().includes('purple')) {
       console.log('✅ Second turn (remembered color):', response2);
     } else {
       console.error('❌ Failed to remember color:', response2);
       throw new Error('Conversation memory test failed');
     }
-    
+
     // Third turn: test deeper context
     const { text: response3 } = await generateText({
       model: claudeCode('sonnet'),
       messages: [
-        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Remember this.' },
+        { role: 'user', content: 'My favorite color is purple and I live in Seattle. Just acknowledge this information.' },
         { role: 'assistant', content: response1 },
         { role: 'user', content: 'What is my favorite color?' },
         { role: 'assistant', content: response2 },

--- a/examples/tool-streaming.ts
+++ b/examples/tool-streaming.ts
@@ -1,0 +1,131 @@
+/**
+ * Example: Tool Streaming Events
+ *
+ * Streams a conversation that triggers Claude Code's built-in tools and prints the
+ * intermediate tool events emitted by the Vercel AI SDK integration.
+ *
+ * Requirements:
+ *   - `npm run build` (so ../dist is up to date)
+ *   - `claude login` and the CLI tools available on your PATH
+ *   - Node.js ≥ 18
+ */
+
+import { streamText } from 'ai';
+import type { CanUseTool } from '@anthropic-ai/claude-code';
+import { claudeCode } from '../dist/index.js';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const allowAllTools: CanUseTool = async (_toolName, input) => ({
+  behavior: 'allow',
+  updatedInput: input,
+});
+
+async function main() {
+  const exampleRoot = dirname(fileURLToPath(import.meta.url));
+  const workspaceRoot = resolve(exampleRoot, '..');
+  const readmePath = resolve(workspaceRoot, 'README.md');
+
+  const result = streamText({
+    model: claudeCode('sonnet', {
+      streamingInput: 'always',
+      canUseTool: allowAllTools,
+      permissionMode: 'bypassPermissions',
+      allowedTools: ['Bash', 'Read'],
+      cwd: workspaceRoot,
+    }),
+    prompt: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `List the project directory and then read ${readmePath}. Summarize the findings once the tools finish.`,
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log('Listening for tool and text events...\n');
+
+  const stream = result.fullStream as AsyncIterable<any>;
+
+  for await (const part of stream) {
+    switch (part.type) {
+      case 'start':
+        console.log('⚙️ generation started');
+        break;
+      case 'start-step':
+        console.log('➡️ start-step', part.request ?? {});
+        break;
+      case 'stream-start':
+        console.log('⚡ stream-start');
+        if (Array.isArray(part.warnings) && part.warnings.length > 0) {
+          console.log(
+            '  warnings:',
+            part.warnings.map((warning: unknown) => JSON.stringify(warning)),
+          );
+        }
+        break;
+      case 'response-metadata':
+        console.log(`ℹ️ session ${part.id ?? 'unknown'} (model ${part.modelId ?? 'unknown'})`);
+        break;
+      case 'tool-input-start':
+        console.log(`🔧 tool-input-start → ${part.toolName} (${part.id})`);
+        break;
+      case 'tool-input-delta':
+        console.log(`   ↳ input delta: ${part.delta}`);
+        break;
+      case 'tool-input-end':
+        console.log(`   ↳ input end (${part.id})`);
+        break;
+      case 'tool-call':
+        console.log(`🚀 tool-call → ${part.toolName} (${part.toolCallId})`);
+        break;
+      case 'tool-error':
+        console.error('⚠️ tool-error:', part.toolName, part.error);
+        break;
+      case 'tool-result':
+        console.log(`📄 tool-result ← ${part.toolName} (${part.toolCallId})`);
+        const toolResult = part.result ?? part.output;
+        if (toolResult !== undefined) {
+          console.dir(toolResult, { depth: 4 });
+        } else {
+          console.log('   (provider reported no structured result)');
+        }
+        break;
+      case 'text-start':
+        console.log('💬 text-start');
+        break;
+      case 'text-delta':
+        {
+          const chunk = part.delta ?? part.text;
+          if (typeof chunk === 'string') {
+            process.stdout.write(chunk);
+          } else {
+            console.dir(chunk, { depth: 2 });
+          }
+        }
+        break;
+      case 'text-end':
+        console.log('\n💬 text-end\n');
+        break;
+      case 'finish':
+        console.log('✅ finish', part.finishReason);
+        console.log('   usage:', part.usage ?? part.totalUsage);
+        break;
+      case 'error':
+        console.error('❌ error part:', part.error);
+        break;
+      default:
+        console.log('⋯ other part:', part);
+        break;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Example failed:', error);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
                 "@ai-sdk/provider-utils": "3.0.3",
-                "@anthropic-ai/claude-code": "^1.0.94",
+                "@anthropic-ai/claude-code": "^1.0.128",
                 "jsonc-parser": "^3.3.1"
             },
             "devDependencies": {
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@anthropic-ai/claude-code": {
-            "version": "1.0.117",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.117.tgz",
-            "integrity": "sha512-ZSBFpwPqMZJZq9//BYSW0MLGQY0svAtncPe2EVxohO87Gym6Dqi+IRSVZkWSwF07gmzZH3luqrepX3q33l7T+Q==",
+            "version": "1.0.128",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.128.tgz",
+            "integrity": "sha512-uUg5cFMJfeQetQzFw76Vpbro6DAXst2Lpu8aoZWRFSoQVYu5ZSAnbBoxaWmW/IgnHSqIIvtMwzCoqmcA9j9rNQ==",
             "license": "SEE LICENSE IN README.md",
             "bin": {
                 "claude": "cli.js"
@@ -202,6 +202,7 @@
             "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@edge-runtime/primitives": "6.0.0"
             },
@@ -1587,6 +1588,7 @@
             "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -1627,6 +1629,7 @@
             "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.34.0",
                 "@typescript-eslint/types": "8.34.0",
@@ -1953,6 +1956,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2329,6 +2333,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -2383,6 +2388,7 @@
             "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3521,6 +3527,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4065,6 +4072,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4237,6 +4245,7 @@
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4316,12 +4325,21 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/vite-node/node_modules/undici-types": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+            "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/vite-node/node_modules/vite": {
             "version": "7.1.6",
@@ -4404,6 +4422,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -4519,6 +4538,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4532,6 +4552,7 @@
             "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.6",
@@ -4776,6 +4797,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
                 "@ai-sdk/provider-utils": "3.0.3",
-                "@anthropic-ai/claude-code": "1.0.94",
+                "@anthropic-ai/claude-code": "^1.0.94",
                 "jsonc-parser": "^3.3.1"
             },
             "devDependencies": {
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@anthropic-ai/claude-code": {
-            "version": "1.0.94",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.94.tgz",
-            "integrity": "sha512-RkiS860XpvCrh5RBE2lluMh2O+4uZgw07JKTnHwfeBDrOPxRbvNCrHCk1ZefCmAvYTjWV6GbuMN+hy5k7I3eVw==",
+            "version": "1.0.117",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.117.tgz",
+            "integrity": "sha512-ZSBFpwPqMZJZq9//BYSW0MLGQY0svAtncPe2EVxohO87Gym6Dqi+IRSVZkWSwF07gmzZH3luqrepX3q33l7T+Q==",
             "license": "SEE LICENSE IN README.md",
             "bin": {
                 "claude": "cli.js"
@@ -4025,14 +4025,14 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4042,11 +4042,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -4290,11 +4293,14 @@
             }
         },
         "node_modules/vite-node/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -4318,18 +4324,18 @@
             }
         },
         "node_modules/vite-node/node_modules/vite": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.5.tgz",
-            "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.6.tgz",
+            "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.6",
-                "picomatch": "^4.0.2",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
-                "rollup": "^4.40.0",
-                "tinyglobby": "^0.2.14"
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.3",
-        "@anthropic-ai/claude-code": "1.0.94",
+        "@anthropic-ai/claude-code": "^1.0.94",
         "jsonc-parser": "^3.3.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.3",
-        "@anthropic-ai/claude-code": "^1.0.94",
+        "@anthropic-ai/claude-code": "^1.0.128",
         "jsonc-parser": "^3.3.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-sdk-provider-claude-code",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "description": "AI SDK v5 provider for Claude via Claude Code SDK (use Pro/Max subscription)",
     "keywords": [
         "ai-sdk",

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -657,6 +657,8 @@ describe('ClaudeCodeLanguageModel', () => {
         id: toolUseId,
       });
 
+      expect(events.indexOf(toolInputDelta!)).toBeLessThan(events.indexOf(toolInputEnd!));
+
       expect(toolCall).toMatchObject({
         type: 'tool-call',
         toolCallId: toolUseId,
@@ -669,6 +671,9 @@ describe('ClaudeCodeLanguageModel', () => {
           },
         },
       });
+
+      expect(events.indexOf(toolInputEnd!)).toBeLessThan(events.indexOf(toolCall!));
+      expect(events.indexOf(toolCall!)).toBeLessThan(events.indexOf(toolResult!));
 
       expect(toolResult).toMatchObject({
         type: 'tool-result',

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -2,6 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
 import type { LanguageModelV2StreamPart } from '@ai-sdk/provider';
 
+// Extend stream part union locally to include provider-specific 'tool-error'
+type ToolErrorPart = {
+  type: 'tool-error';
+  toolCallId: string;
+  toolName: string;
+  error: string;
+  providerExecuted: true;
+  providerMetadata?: Record<string, unknown>;
+};
+type ExtendedStreamPart = LanguageModelV2StreamPart | ToolErrorPart;
+
 // Mock the SDK module with factory function
 vi.mock('@anthropic-ai/claude-code', () => {
   return {
@@ -624,7 +635,7 @@ describe('ClaudeCodeLanguageModel', () => {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'List files' }] }],
       });
 
-      const events: LanguageModelV2StreamPart[] = [];
+      const events: ExtendedStreamPart[] = [];
       const reader = stream.getReader();
 
       while (true) {
@@ -729,7 +740,7 @@ describe('ClaudeCodeLanguageModel', () => {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Read file' }] }],
       });
 
-      const events: LanguageModelV2StreamPart[] = [];
+      const events: ExtendedStreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -756,6 +767,672 @@ describe('ClaudeCodeLanguageModel', () => {
         toolName,
         input: JSON.stringify({ file_path: '/tmp/example.txt' }),
         providerExecuted: true,
+      });
+    });
+
+    it('emits tool-error events for tool failures and orders after tool-call', async () => {
+      const toolUseId = 'toolu_error';
+      const toolName = 'Read';
+      const errorMessage = 'File not found: /nonexistent.txt';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  id: toolUseId,
+                  name: toolName,
+                  input: { file_path: '/nonexistent.txt' },
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                {
+                  type: 'tool_error',
+                  tool_use_id: toolUseId,
+                  name: toolName,
+                  error: errorMessage,
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'error-session',
+            usage: { input_tokens: 10, output_tokens: 0 },
+            total_cost_usd: 0.001,
+            duration_ms: 100,
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Read missing file' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const toolError = events.find((e) => e.type === 'tool-error');
+      const toolCall = events.find((e) => e.type === 'tool-call');
+
+      expect(toolCall).toMatchObject({
+        type: 'tool-call',
+        toolCallId: toolUseId,
+        toolName,
+        providerExecuted: true,
+      });
+
+      expect(toolError).toMatchObject({
+        type: 'tool-error',
+        toolCallId: toolUseId,
+        toolName,
+        error: errorMessage,
+        providerExecuted: true,
+      });
+
+      expect(events.indexOf(toolCall!)).toBeLessThan(events.indexOf(toolError!));
+    });
+
+    it('emits only one tool-call for multiple tool-result chunks', async () => {
+      const toolUseId = 'toolu_chunked';
+      const toolName = 'Bash';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  id: toolUseId,
+                  name: toolName,
+                  input: { command: 'echo "test"' },
+                },
+              ],
+            },
+          };
+          // First result chunk
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: toolUseId,
+                  name: toolName,
+                  content: 'Chunk 1\n',
+                  is_error: false,
+                },
+              ],
+            },
+          };
+          // Second result chunk - same tool_use_id
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: toolUseId,
+                  name: toolName,
+                  content: 'Chunk 2\n',
+                  is_error: false,
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'chunked-session',
+            usage: { input_tokens: 15, output_tokens: 5 },
+            total_cost_usd: 0.002,
+            duration_ms: 200,
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Run command' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const toolCalls = events.filter((e) => e.type === 'tool-call');
+      const toolResults = events.filter((e) => e.type === 'tool-result');
+
+      expect(toolCalls).toHaveLength(1);
+      expect(toolResults).toHaveLength(2);
+      expect(toolCalls[0]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: toolUseId,
+        toolName,
+      });
+    });
+
+    it('synthesizes lifecycle for orphaned tool results (no prior tool_use)', async () => {
+      const toolUseId = 'toolu_orphan';
+      const toolName = 'Read';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: toolUseId,
+                  name: toolName,
+                  content: 'OK',
+                  is_error: false,
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'orphan-session',
+            usage: { input_tokens: 5, output_tokens: 1 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Run' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const inputStartIndex = events.findIndex((e) => e.type === 'tool-input-start');
+      const inputEndIndex = events.findIndex((e) => e.type === 'tool-input-end');
+      const callIndex = events.findIndex((e) => e.type === 'tool-call');
+      const resultIndex = events.findIndex((e) => e.type === 'tool-result');
+
+      expect(inputStartIndex).toBeGreaterThan(-1);
+      expect(inputEndIndex).toBeGreaterThan(inputStartIndex);
+      expect(callIndex).toBeGreaterThan(inputEndIndex);
+      expect(resultIndex).toBeGreaterThan(callIndex);
+    });
+
+    // Note: Exhaustive size-limit error conditions are validated by unit-level logic; streaming emits metadata and/or errors.
+
+    it('warns for large tool inputs but processes them', async () => {
+      const toolUseId = 'toolu_large';
+      const toolName = 'LargeTool';
+      const largeInput = 'x'.repeat(200_000); // 200KB
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn');
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  id: toolUseId,
+                  name: toolName,
+                  input: { data: largeInput },
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'large-session',
+            usage: { input_tokens: 10, output_tokens: 0 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Large input test' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const toolCall = events.find((e) => e.type === 'tool-call');
+      expect(toolCall).toBeDefined();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('skips delta calculation for large inputs', async () => {
+      const toolUseId = 'toolu_large_delta';
+      const toolName = 'LargeDeltaTool';
+      const largeInput = 'x'.repeat(50_000); // 50KB
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  id: toolUseId,
+                  name: toolName,
+                  input: { data: largeInput },
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'large-delta-session',
+            usage: { input_tokens: 10, output_tokens: 0 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Large delta test' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const deltas = events.filter((e) => e.type === 'tool-input-delta');
+      expect(deltas).toHaveLength(0);
+      const toolCall = events.find((e) => e.type === 'tool-call');
+      expect(toolCall).toBeDefined();
+    });
+
+    it('does not emit delta for non-prefix input updates', async () => {
+      const toolUseId = 'toolu_nonprefix';
+      const toolName = 'TestTool';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          // First chunk
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'tool_use', id: toolUseId, name: toolName, input: { arg: 'initial' } },
+              ],
+            },
+          };
+          // Second chunk - non-prefix replacement
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'tool_use', id: toolUseId, name: toolName, input: { arg: 'replaced' } },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'nonprefix-session',
+            usage: { input_tokens: 10, output_tokens: 2 },
+            total_cost_usd: 0.001,
+            duration_ms: 50,
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const deltas = events.filter((e) => e.type === 'tool-input-delta');
+      const toolCall = events.find((e) => e.type === 'tool-call') as any;
+
+      expect(deltas).toHaveLength(1);
+      expect((deltas[0] as any).delta).toBe(JSON.stringify({ arg: 'initial' }));
+      expect(toolCall.input).toBe(JSON.stringify({ arg: 'replaced' }));
+    });
+
+    it('emits multiple tool-error chunks without duplicate tool-call', async () => {
+      const toolUseId = 'toolu_multi_error';
+      const toolName = 'Read';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'tool_use', id: toolUseId, name: toolName, input: { file: 'x' } },
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                { type: 'tool_error', tool_use_id: toolUseId, name: toolName, error: 'e1' },
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                { type: 'tool_error', tool_use_id: toolUseId, name: toolName, error: 'e2' },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'multierror-session',
+            usage: { input_tokens: 1, output_tokens: 0 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'run' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const toolCalls = events.filter((e) => e.type === 'tool-call');
+      const toolErrors = events.filter((e) => e.type === 'tool-error');
+      expect(toolCalls).toHaveLength(1);
+      expect(toolErrors).toHaveLength(2);
+    });
+
+    it('handles multiple concurrent tool calls', async () => {
+      const id1 = 't1';
+      const id2 = 't2';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'tool_use', id: id1, name: 'Read', input: { p: 'a' } },
+                { type: 'tool_use', id: id2, name: 'Bash', input: { c: 'echo' } },
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                { type: 'tool_result', tool_use_id: id1, name: 'Read', content: 'A', is_error: false },
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                { type: 'tool_result', tool_use_id: id2, name: 'Bash', content: 'B', is_error: false },
+              ],
+            },
+          };
+          yield { type: 'result', subtype: 'success', session_id: 'concurrent', usage: { input_tokens: 1, output_tokens: 1 } };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'run' }] }] } as any);
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const toolCalls = events.filter((e) => e.type === 'tool-call');
+      const toolResults = events.filter((e) => e.type === 'tool-result');
+      expect(toolCalls).toHaveLength(2);
+      expect(toolResults).toHaveLength(2);
+    });
+
+    it('supports interleaved text and tool events', async () => {
+      const toolUseId = 'tool_interleave';
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'assistant', message: { content: [{ type: 'text', text: 'Intro ' }] } };
+          yield { type: 'assistant', message: { content: [{ type: 'tool_use', id: toolUseId, name: 'Read', input: { p: '/f' } }] } };
+          yield { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, name: 'Read', content: 'OK', is_error: false }] } };
+          yield { type: 'assistant', message: { content: [{ type: 'text', text: ' Outro' }] } };
+          yield { type: 'result', subtype: 'success', session_id: 'inter', usage: { input_tokens: 1, output_tokens: 1 } };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+      const { stream } = await model.doStream({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] } as any);
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const firstTextIndex = events.findIndex((e) => e.type === 'text-delta');
+      const toolCallIndex = events.findIndex((e) => e.type === 'tool-call');
+      const lastTextIndex = events.findIndex((e, i) => i > toolCallIndex && e.type === 'text-delta');
+      expect(firstTextIndex).toBeGreaterThan(-1);
+      expect(toolCallIndex).toBeGreaterThan(firstTextIndex);
+      expect(lastTextIndex).toBeGreaterThan(toolCallIndex);
+    });
+
+    it('includes JSON validation warnings in streaming finish metadata', async () => {
+      const malformedJson = 'Here is the JSON: {"a": 1, "b": invalid}';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'text', text: malformedJson }],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'json-warn-session',
+            usage: { input_tokens: 10, output_tokens: 20 },
+            total_cost_usd: 0.002,
+            duration_ms: 100,
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] }],
+        responseFormat: { type: 'json', schema: {} } as any,
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const finishEvent = events.find((e) => e.type === 'finish') as any;
+      expect(finishEvent).toBeDefined();
+      const metadata = finishEvent.providerMetadata?.['claude-code'];
+      expect(metadata?.warnings).toBeDefined();
+      expect(metadata.warnings.length).toBeGreaterThan(0);
+      expect(metadata.warnings[0]).toMatchObject({ type: 'other' });
+    });
+
+    it('warns and skips messages with invalid structure', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn');
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          // Assistant message missing content
+          yield {
+            type: 'assistant',
+            message: { role: 'assistant' },
+          } as any;
+          // User message missing content
+          yield {
+            type: 'user',
+            message: { role: 'user' },
+          } as any;
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'invalid-struct-session',
+            usage: { input_tokens: 0, output_tokens: 0 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'noop' }] }],
+      } as any);
+
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('uses consistent fallback name for unknown tools', async () => {
+      const toolUseId = 'toolu_unknown_name';
+
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  id: toolUseId,
+                  // name omitted/unknown
+                  input: { x: 1 },
+                } as any,
+              ],
+            },
+          };
+          yield {
+            type: 'user',
+            message: {
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: toolUseId,
+                  content: 'ok',
+                },
+              ],
+            },
+          };
+          yield {
+            type: 'result',
+            subtype: 'success',
+            session_id: 's-unknown',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        },
+      };
+
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const { stream } = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'run' }] }],
+      } as any);
+
+      const events: ExtendedStreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const toolCall = events.find((e) => e.type === 'tool-call');
+      expect(toolCall).toMatchObject({
+        type: 'tool-call',
+        toolName: 'unknown-tool',
       });
     });
 

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1158,6 +1158,9 @@ export class ClaudeCodeLanguageModel implements LanguageModelV2 {
                     ...(message.total_cost_usd !== undefined && { costUsd: message.total_cost_usd }),
                     ...(message.duration_ms !== undefined && { durationMs: message.duration_ms }),
                     ...(rawUsage !== undefined && { rawUsage: rawUsage as JSONValue }),
+                    // JSON validation warnings are collected during streaming and included
+                    // in providerMetadata since the AI SDK's finish event doesn't support
+                    // a top-level warnings field (unlike stream-start which was already emitted)
                     ...(streamWarnings.length > 0 && { warnings: warningsJson as unknown as JSONValue }),
                   },
                 },


### PR DESCRIPTION
## Summary

Adds comprehensive tool streaming support with proper event lifecycle, error handling, and performance optimizations.

**Key Changes:**
- Implement all AI SDK v5 tool streaming events: `tool-input-start`, `tool-input-delta`, `tool-input-end`, `tool-call`, `tool-result`, and `tool-error`
- Add tool-error event emission for failed tool executions (distinct from tool-result with isError)
- Fix event ordering to prevent duplicate tool-call events on multi-chunk results
- Add tool input size limits (1MB hard limit, 100KB warning, 10KB delta threshold)
- Upgrade @anthropic-ai/claude-code from 1.0.94 to 1.0.128
- Add comprehensive JSDoc for tool streaming lifecycle

**Bug Fixes:**
- Prevent duplicate tool-input-delta emissions for non-prefix updates
- Ensure tool-call emitted before tool-result/tool-error
- Handle orphaned tool results with proper lifecycle synthesis
- Fix integration test to avoid triggering MCP memory server in v1.0.128

**Documentation:**
- Clarify tool-input-delta semantics (prefix-only updates)
- Add performance considerations section
- Update event ordering guarantees

**Testing:**
- Add test coverage for tool-error events
- Add tests for multi-chunk tool results
- Add tests for input size limits
- All 282 tests passing

Resolves #36

## Testing
```bash
npm run build
npm run typecheck
npm run lint
npm run test
```