### PR TITLE
Upgrade anthropic-ai/claude-code to mitigate security risk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.3",
-                "@anthropic-ai/claude-code": "1.0.94",
+                "@ai-sdk/provider-utils": "3.0.9",
+                "@anthropic-ai/claude-code": "1.0.119",
                 "jsonc-parser": "^3.3.1"
             },
             "devDependencies": {
@@ -21,7 +21,7 @@
                 "@typescript-eslint/eslint-plugin": "8.34.0",
                 "@typescript-eslint/parser": "8.34.0",
                 "@vitest/coverage-v8": "^3.2.4",
-                "ai": "5.0.14",
+                "ai": "5.0.47",
                 "eslint": "9.28.0",
                 "globals": "16.2.0",
                 "tsup": "8.5.0",
@@ -37,14 +37,14 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.6.tgz",
-            "integrity": "sha512-JuSj1MtTr4vw2VBBth4wlbciQnQIV0o1YV9qGLFA+r85nR5H+cJp3jaYE0nprqfzC9rYG8w9c6XGHB3SDKgcgA==",
+            "version": "1.0.24",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.24.tgz",
+            "integrity": "sha512-Mwp0yYXrEnENoDrc7IH9yVRVJ7RrDW0CXWDtyz1BiyqccbtdWhAKu4wtrDMx2FkeK5riiME1kYYdjRnlba3UFw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.3"
+                "@ai-sdk/provider-utils": "3.0.9"
             },
             "engines": {
                 "node": ">=18"
@@ -66,30 +66,20 @@
             }
         },
         "node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
-            "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.9.tgz",
+            "integrity": "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
                 "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.3",
-                "zod-to-json-schema": "^3.24.1"
+                "eventsource-parser": "^3.0.5"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4"
-            }
-        },
-        "node_modules/@ai-sdk/provider-utils/node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -107,9 +97,9 @@
             }
         },
         "node_modules/@anthropic-ai/claude-code": {
-            "version": "1.0.94",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.94.tgz",
-            "integrity": "sha512-RkiS860XpvCrh5RBE2lluMh2O+4uZgw07JKTnHwfeBDrOPxRbvNCrHCk1ZefCmAvYTjWV6GbuMN+hy5k7I3eVw==",
+            "version": "1.0.119",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.119.tgz",
+            "integrity": "sha512-0SxTgt7Htr2okxL2Uk0Mv5eB8JxBrRCZCdtTNwuYC/OBl2F7UDM8YFtIwHz97ygCoJw49j7SL6s+/MIZGaEzrA==",
             "license": "SEE LICENSE IN README.md",
             "bin": {
                 "claude": "cli.js"
@@ -1971,15 +1961,15 @@
             }
         },
         "node_modules/ai": {
-            "version": "5.0.14",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.14.tgz",
-            "integrity": "sha512-xiujFa879skB7YxGzbeHAxepsr6AEaWcHPXrc5a9MRM6p4WdVAwn6mGwVZkBnhqGfZtXFr4LUnU2ayvcjWp5ig==",
+            "version": "5.0.47",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.47.tgz",
+            "integrity": "sha512-/DKfU9tTsQVcUYSDCTu1L7jmvEgzUWOr1xf5UHwwDbRf/HED8LDb60QlWYs6f4BkZsVoLvpliCSjliXiRZywFQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "1.0.6",
+                "@ai-sdk/gateway": "1.0.24",
                 "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.3",
+                "@ai-sdk/provider-utils": "3.0.9",
                 "@opentelemetry/api": "1.9.0"
             },
             "engines": {
@@ -2603,12 +2593,12 @@
             }
         },
         "node_modules/eventsource-parser": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
-            "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
             "license": "MIT",
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/expect-type": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     },
     "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.3",
-        "@anthropic-ai/claude-code": "1.0.94",
+        "@ai-sdk/provider-utils": "3.0.9",
+        "@anthropic-ai/claude-code": "1.0.119",
         "jsonc-parser": "^3.3.1"
     },
     "devDependencies": {
@@ -76,7 +76,7 @@
         "@typescript-eslint/eslint-plugin": "8.34.0",
         "@typescript-eslint/parser": "8.34.0",
         "@vitest/coverage-v8": "^3.2.4",
-        "ai": "5.0.14",
+        "ai": "5.0.47",
         "eslint": "9.28.0",
         "globals": "16.2.0",
         "tsup": "8.5.0",


### PR DESCRIPTION
There is a high severity security flaw in the specified version (1.0.94 < 1.0.105) of @anthropic-ai/claude-code https://www.cve.org/CVERecord?id=CVE-2025-58764 so npm complains on install This PR upgrades that dependency along with the other AI packages