### PR TITLE
chore: update npm tag from v1 to v1-claude-code-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@
 
 ### Installing the Right Version
 
-**For AI SDK v5 (recommended):**
+**For AI SDK v5 with Claude Agent SDK (recommended):**
 
 ```bash
 npm install ai-sdk-provider-claude-code ai
 # or explicitly: npm install ai-sdk-provider-claude-code@latest
+```
+
+**For AI SDK v5 with Claude Code SDK (legacy):**
+
+```bash
+npm install ai-sdk-provider-claude-code@v1-claude-code-sdk ai
 ```
 
 **For AI SDK v4 (legacy):**


### PR DESCRIPTION
## Summary

Updates the version compatibility table in README to reflect the correct npm dist-tag for v1.x releases.

## Issue

The npm tag `v1` is not valid as it conflicts with semver range syntax. When attempting to add it, npm returns:
```
npm error Tag name must not be a valid SemVer range: v1
```

## Solution

Updated the version compatibility table to use `v1-claude-code-sdk` which is the actual tag that was added to npm for version 1.2.0.

## Changes

- Updated README.md version compatibility table
- Changed NPM Tag from `v1` to `v1-claude-code-sdk`

## Verification

```bash
npm view ai-sdk-provider-claude-code dist-tags
# {
#   'ai-sdk-v4': '0.2.3',
#   latest: '2.0.0',
#   'v1-claude-code-sdk': '1.2.0'
# }
```

## Installation

Users can now install v1.x using:
```bash
npm install ai-sdk-provider-claude-code@v1-claude-code-sdk
```