### PR TITLE
chore: release v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "AI SDK v5 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
Documentation-only release to update README on npm with correct installation examples and npm tag information.

## Changes
- No code changes
- README was updated in previous PR to show correct npm tag (`v1-claude-code-sdk`)
- This release updates the npm listing to show the corrected documentation