### PR TITLE
fix: Update MinimalCallToolResult type to match MCP SDK v1.13+ specification

### DIFF
--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -7,9 +7,21 @@ import { type ZodRawShape, type ZodObject } from 'zod';
  * Each tool provides a description, a Zod object schema, and a handler.
  */
 export type MinimalCallToolResult = {
-  content: Array<{ type: string; [key: string]: unknown }>;
+  content: Array<
+    | { type: 'text'; text: string; [key: string]: unknown }
+    | { type: 'image'; data: string; mimeType: string; [key: string]: unknown }
+    | { type: 'audio'; data: string; mimeType: string; [key: string]: unknown }
+    | {
+        type: 'resource';
+        resource:
+          | { uri: string; text: string; mimeType?: string; [key: string]: unknown }
+          | { uri: string; blob: string; mimeType?: string; [key: string]: unknown };
+        [key: string]: unknown;
+      }
+  >;
   isError?: boolean;
-  structuredContent?: unknown;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
 };
 
 export function createCustomMcpServer<


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error when installing `ai-sdk-provider-claude-code` as a GitHub dependency in Task Master.

## Problem

When Task Master tried to install ben-vargas's `fix-claude-code-3359-truncation` branch as a GitHub dependency, the build failed with:

```
src/mcp-helpers.ts(30,7): error TS2345: 
Type 'MinimalCallToolResult' is not assignable to expected MCP type
Property 'resource' is missing in type '{ [key: string]: unknown; type: string; }'
```

## Root Cause

The `MinimalCallToolResult` type used a loose content array definition that didn't explicitly define the discriminated union of content types. When TypeScript compiled the package in a context where MCP SDK v1.13+ types were present, it couldn't reconcile the generic `{ type: string; [key: string]: unknown }[]` with the stricter MCP SDK spec that requires explicit `resource` content types.

## Changes

Updated `src/mcp-helpers.ts` line 9-25 to define `MinimalCallToolResult` with:
- Explicit discriminated union for content types: `text`, `image`, `audio`, `resource`
- Proper `resource` type definition with both `text` and `blob` variants
- Added `_meta` field for metadata
- Maintained backward compatibility with index signature `[key: string]: unknown`

## Testing

✅ **Standalone build**: Package builds successfully (`npm install` && `npm test` - all 302 tests pass)

✅ **Task Master integration**: Successfully tested with actual Task Master workload
```bash
# Before fix: Failed with JSON truncation at 8000 chars
task-master parse-prd large-prd.txt -n 10
# ERROR: Unterminated string in JSON at position 8000

# After fix: Success!
task-master parse-prd large-prd.txt -n 10  
# ✔ Tasks generated successfully!
# Successfully generated 13 new tasks
```

- PRD file: 1014 lines, 37,839 bytes  
- Generated: 13 tasks (actual count, not limited to requested 10)
- No truncation errors
- Ben-vargas's truncation detection logic working correctly

## Compatibility

- ✅ Backward compatible with existing code
- ✅ Works with MCP SDK v1.13.3 and v1.18.2 (both present in Task Master)
- ✅ All existing tests pass
- ✅ No breaking changes to API

## Related Issues

- Fixes build failure reported in eyaltoledano/claude-task-master#1315  
- Complements truncation fix in d4dc95d

## Validation

Tested in production-like environment with Task Master v0.29.0 parsing real PRD files.

cc @eyaltoledano @Crunchyman-ralph for Task Master team visibility