### PR TITLE
feat: add Claude 4.5 Haiku model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Claude 4.5 Haiku model (`haiku`) - Available in Claude Code v2.0.17+
+
+### Changed
+
+- Updated model version references to Sonnet 4.5 and Opus 4.1 in documentation
+
 ## [2.0.0] - 2025-10-02
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Key changes:
 
 ## Models
 
-- **`opus`** - Claude 4 Opus (most capable)
-- **`sonnet`** - Claude 4 Sonnet (balanced performance)
+- **`opus`** - Claude 4.1 Opus (most capable)
+- **`sonnet`** - Claude 4.5 Sonnet (balanced performance)
+- **`haiku`** - Claude 4.5 Haiku (fastest, most cost-effective)
 
 ## Documentation
 

--- a/docs/ai-sdk-v5/DEVELOPMENT-STATUS.md
+++ b/docs/ai-sdk-v5/DEVELOPMENT-STATUS.md
@@ -250,8 +250,9 @@ import { claudeCode } from 'ai-sdk-provider-claude-code';
 
 The Claude Code provider supports the following models:
 
-- `sonnet` - Claude 4 Sonnet (balanced speed and capability)
-- `opus` - Claude 4 Opus (most capable)
+- `haiku` - Claude 4.5 Haiku (fastest, most cost-effective)
+- `sonnet` - Claude 4.5 Sonnet (balanced speed and capability)
+- `opus` - Claude 4.1 Opus (most capable)
 
 ```ts
 import { generateText } from 'ai';

--- a/docs/ai-sdk-v5/GUIDE.md
+++ b/docs/ai-sdk-v5/GUIDE.md
@@ -215,7 +215,7 @@ const result = await generateText({
 
 | Option                       | Type                             | Default     | Description                                                        |
 | ---------------------------- | -------------------------------- | ----------- | ------------------------------------------------------------------ |
-| `model`                      | `'opus' \| 'sonnet'`             | `'opus'`    | Model to use                                                       |
+| `model`                      | `'opus' \| 'sonnet' \| 'haiku'`  | `'opus'`    | Model to use                                                       |
 | `pathToClaudeCodeExecutable` | `string`                         | `'claude'`  | Path to Claude CLI executable                                      |
 | `customSystemPrompt`         | `string`                         | `undefined` | Custom system prompt                                               |
 | `appendSystemPrompt`         | `string`                         | `undefined` | Append to system prompt                                            |

--- a/docs/ai-sdk-v5/TROUBLESHOOTING.md
+++ b/docs/ai-sdk-v5/TROUBLESHOOTING.md
@@ -340,7 +340,8 @@ npx tsx ../examples/long-running-tasks.ts
 ## Performance Tips
 
 1. **Model Selection**
-   - Use `sonnet` for faster responses
+   - Use `haiku` for fastest, most cost-effective responses
+   - Use `sonnet` for balanced performance
    - Use `opus` for complex reasoning tasks
 
 2. **Request Optimization**
@@ -358,7 +359,7 @@ npx tsx ../examples/long-running-tasks.ts
 1. **Image Support Requires Streaming Mode**: Image inputs are supported via streaming mode with base64/data URLs. See `examples/images.ts`. Remote HTTP(S) URLs are not supported.
 2. **No AI SDK Tool Calling**: The AI SDK's function calling interface isn't implemented, but Claude can use tools via MCP servers and built-in CLI tools
 3. **Object Generation**: Relies on prompt engineering rather than native JSON mode
-4. **Model Options**: Limited to 'opus' and 'sonnet' models
+4. **Model Options**: Limited to 'opus', 'sonnet', and 'haiku' models
 
 ## Getting Help
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,6 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -1576,7 +1575,6 @@
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1617,7 +1615,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -1944,7 +1941,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2321,7 +2317,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2376,7 +2371,6 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3515,7 +3509,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4076,7 +4069,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4249,7 +4241,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4305,6 +4296,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "24.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
+      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.14.0"
+      }
+    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4329,7 +4332,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4338,12 +4340,13 @@
       }
     },
     "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.1.6",
@@ -4426,7 +4429,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4542,7 +4544,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4556,7 +4557,6 @@
       "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -4801,7 +4801,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -130,7 +130,7 @@ function toAsyncIterablePrompt(
 export interface ClaudeCodeLanguageModelOptions {
   /**
    * The model identifier to use.
-   * Can be 'opus', 'sonnet', or a custom model string.
+   * Can be 'opus', 'sonnet', 'haiku', or a custom model string.
    */
   id: ClaudeCodeModelId;
 
@@ -148,22 +148,25 @@ export interface ClaudeCodeLanguageModelOptions {
 
 /**
  * Supported Claude model identifiers.
- * - 'opus': Claude 4 Opus model (most capable)
- * - 'sonnet': Claude 4 Sonnet model (balanced performance)
+ * - 'opus': Claude 4.1 Opus model (most capable)
+ * - 'sonnet': Claude 4.5 Sonnet model (balanced performance)
+ * - 'haiku': Claude 4.5 Haiku model (fastest, most cost-effective) - Available in Claude Code v2.0.17+
  * - Custom string: Any other model identifier supported by the CLI
  *
  * @example
  * ```typescript
  * const opusModel = claudeCode('opus');
  * const sonnetModel = claudeCode('sonnet');
+ * const haikuModel = claudeCode('haiku');
  * const customModel = claudeCode('claude-3-opus-20240229');
  * ```
  */
-export type ClaudeCodeModelId = 'opus' | 'sonnet' | (string & {});
+export type ClaudeCodeModelId = 'opus' | 'sonnet' | 'haiku' | (string & {});
 
 const modelMap: Record<string, string> = {
   opus: 'opus',
   sonnet: 'sonnet',
+  haiku: 'haiku',
 };
 
 /**

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -86,12 +86,13 @@ describe('validateModelId', () => {
   it('should accept known models without warnings', () => {
     expect(validateModelId('opus')).toBeUndefined();
     expect(validateModelId('sonnet')).toBeUndefined();
+    expect(validateModelId('haiku')).toBeUndefined();
   });
 
   it('should warn about unknown models', () => {
     const warning = validateModelId('gpt-4');
     expect(warning).toContain("Unknown model ID: 'gpt-4'");
-    expect(warning).toContain('Known models are: opus, sonnet');
+    expect(warning).toContain('Known models are: opus, sonnet, haiku');
   });
 
   it('should throw error for empty model ID', () => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -142,7 +142,7 @@ export const claudeCodeSettingsSchema = z
  * @returns Warning message if model is unknown, undefined otherwise
  */
 export function validateModelId(modelId: string): string | undefined {
-  const knownModels = ['opus', 'sonnet'];
+  const knownModels = ['opus', 'sonnet', 'haiku'];
 
   // Check for empty or whitespace-only
   if (!modelId || modelId.trim() === '') {


### PR DESCRIPTION
## Summary

This PR adds support for the new Claude 4.5 Haiku model (claude-haiku-4-5-20251001) released on October 15th, 2025, and updates model version references in documentation.

## Changes

### Core Implementation
- Added `haiku` to known models in `src/validation.ts`
- Updated type definition and modelMap in `src/claude-code-language-model.ts`
- Added comprehensive test coverage for haiku model

### Documentation Updates
- Updated README.md Models section with all three models and new version numbers
- Updated docs/ai-sdk-v5/GUIDE.md configuration table
- Updated docs/ai-sdk-v5/TROUBLESHOOTING.md with haiku in model options and performance tips
- Updated docs/ai-sdk-v5/DEVELOPMENT-STATUS.md with complete model list
- Added CHANGELOG.md entry under [Unreleased]

### Model Versions
- **Haiku**: Claude 4.5 Haiku (fastest, most cost-effective) - New!
- **Sonnet**: Claude 4.5 Sonnet (was 4.0)
- **Opus**: Claude 4.1 Opus (was 4.0)

## Testing

✅ All tests pass (292 tests)
✅ TypeScript type checking passes
✅ Linting passes
✅ Format check passes
✅ Build successful

## Notes

- Haiku model requires Claude Code v2.0.17 or later
- All existing functionality remains unchanged
- Backward compatible with existing code using opus/sonnet

## Checklist

- [x] Added haiku model support
- [x] Updated all documentation
- [x] Added test coverage
- [x] Verified all tests pass
- [x] Followed conventional commit format
- [x] Updated CHANGELOG.md