### PR TITLE
chore: bump version to 2.0.3 and update claude-agent-sdk to 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2025-10-16
+
 ### Added
 
-- Support for Claude 4.5 Haiku model (`haiku`) - Available in Claude Code v2.0.17+
+- Support for Claude 4.5 Haiku model (`haiku`) - Available in Claude Code v2.0.17+ (#59)
+
+### Fixed
+
+- Improved truncation detection to avoid false positives on malformed JSON (#60)
+  - Added multi-layered validation: position-based, structure validation, minimum size guard, and truncation indicators
+  - Prevents genuine JSON syntax errors from being incorrectly treated as CLI truncation events
+- Updated `MinimalCallToolResult` type to match MCP SDK specification (#60)
+  - Added missing `resource_link` content type
+  - Split resource type into text/blob variants with proper discriminated unions
+  - Resolves TypeScript compilation errors in downstream projects using MCP SDK v1.13+
 
 ### Changed
 
+- Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.0` to `^0.1.20`
+- Updated all example files to use `haiku` model for faster execution
+- Updated Quick Start examples in README.md to use `haiku` model
 - Updated model version references to Sonnet 4.5 and Opus 4.1 in documentation
+
+## [2.0.2] - 2025-10-02
+
+### Changed
+
+- Updated README.md npm tag documentation from `v1` to `v1-claude-code-sdk` (#56)
+- Added explicit installation examples for all versions (v2.x, v1.x, v0.x)
 
 ## [2.0.0] - 2025-10-02
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import { streamText } from 'ai';
 import { claudeCode } from 'ai-sdk-provider-claude-code';
 
 const result = streamText({
-  model: claudeCode('sonnet'),
+  model: claudeCode('haiku'),
   prompt: 'Hello, Claude!',
 });
 
@@ -94,7 +94,7 @@ import { generateText } from 'ai';
 import { claudeCode } from 'ai-sdk-provider-claude-code';
 
 const { text } = await generateText({
-  model: claudeCode('sonnet'),
+  model: claudeCode('haiku'),
   prompt: 'Hello, Claude!',
 });
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,7 +107,7 @@ npx tsx examples/tool-management.ts
 npx tsx examples/long-running-tasks.ts
 ```
 
-**Key concepts**: Custom timeouts, graceful cancellation, retry logic, Opus 4's extended thinking
+**Key concepts**: Custom timeouts, graceful cancellation, retry logic
 
 ### 9. Abort Signal (`abort-signal.ts`)
 
@@ -222,7 +222,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 
 const { object } = await generateObject({
-  model: claudeCode('sonnet'),
+  model: claudeCode('haiku'),
   schema: z.object({
     name: z.string(),
     age: z.number(),
@@ -258,7 +258,7 @@ const messages: ModelMessage[] = [
 ];
 
 const { text } = await generateText({
-  model: claudeCode('sonnet'),
+  model: claudeCode('haiku'),
   messages,
 });
 ```
@@ -269,7 +269,7 @@ const { text } = await generateText({
 import { streamText } from 'ai';
 
 const result = streamText({
-  model: claudeCode('sonnet'),
+  model: claudeCode('haiku'),
   prompt: 'Write a story...',
 });
 
@@ -287,7 +287,7 @@ const timeoutId = setTimeout(() => controller.abort(), 300000); // 5 minutes
 
 try {
   const { text } = await generateText({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     prompt: 'Complex analysis...',
     abortSignal: controller.signal,
   });

--- a/examples/abort-signal.ts
+++ b/examples/abort-signal.ts
@@ -39,7 +39,7 @@ async function main() {
     }, 2000);
 
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt:
         'Write a very long detailed essay about the history of computing. Include at least 10 paragraphs.',
       abortSignal: controller.signal,
@@ -63,7 +63,7 @@ async function main() {
     controller.abort();
 
     await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'This should not execute',
       abortSignal: controller.signal,
     });
@@ -83,7 +83,7 @@ async function main() {
     let charCount = 0;
 
     const { textStream } = streamText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Count slowly from 1 to 20, explaining each number.',
       abortSignal: controller.signal,
     });

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -12,7 +12,7 @@ async function main() {
   try {
     // Basic text generation - streamText returns immediately, not a promise
     const result = streamText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Explain the concept of recursion in programming in 2-3 sentences.',
     });
 

--- a/examples/check-cli.ts
+++ b/examples/check-cli.ts
@@ -16,7 +16,7 @@ async function checkSetup() {
     console.log('Testing SDK connection...');
 
     const { text, usage } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Say "Hello from Claude" and nothing else.',
     });
 

--- a/examples/conversation-history.ts
+++ b/examples/conversation-history.ts
@@ -15,7 +15,7 @@ import type { CoreMessage } from 'ai';
 async function testConversation() {
   console.log('🧪 Testing conversation with message history...');
 
-  const model = claudeCode('sonnet');
+  const model = claudeCode('haiku');
   const messages: CoreMessage[] = [];
 
   // First turn

--- a/examples/custom-config.ts
+++ b/examples/custom-config.ts
@@ -30,7 +30,7 @@ async function main() {
 
     console.log('1️⃣ Using provider with default settings:');
     const { text: response1 } = await generateText({
-      model: customProvider('opus'), // Uses default settings
+      model: customProvider('haiku'), // Uses default settings
       prompt: 'What is the capital of France? Answer in one word.',
     });
     console.log('Response:', response1);
@@ -38,7 +38,7 @@ async function main() {
     // Example 2: Override settings for specific model instance
     console.log('\n2️⃣ Model with custom settings:');
     const { text: response2 } = await generateText({
-      model: customProvider('sonnet', {
+      model: customProvider('haiku', {
         // These settings override the provider defaults
         permissionMode: 'default', // Ask for permissions
         maxTurns: 5, // Limit conversation turns
@@ -49,7 +49,7 @@ async function main() {
 
     // Example 3: Using tool restrictions
     console.log('\n3️⃣ Model with tool restrictions:');
-    const safeModel = customProvider('sonnet', {
+    const safeModel = customProvider('haiku', {
       // Only allow read operations
       allowedTools: ['Read', 'LS', 'Grep', 'Glob'],
       // Explicitly block write operations
@@ -62,26 +62,26 @@ async function main() {
     });
     console.log('Response:', response3);
 
-    // Example 4: Different models from same provider
-    console.log('\n4️⃣ Using different models:');
-    const opusModel = customProvider('opus');
-    const sonnetModel = customProvider('sonnet');
+    // Example 4: Multiple model instances from same provider
+    console.log('\n4️⃣ Using multiple model instances:');
+    const haikuModel1 = customProvider('haiku');
+    const haikuModel2 = customProvider('haiku');
 
     // Quick comparison
     const prompt = 'Explain quantum computing in exactly 10 words.';
 
-    const { text: opusResponse } = await generateText({
-      model: opusModel,
+    const { text: response4a } = await generateText({
+      model: haikuModel1,
       prompt,
     });
 
-    const { text: sonnetResponse } = await generateText({
-      model: sonnetModel,
+    const { text: response4b } = await generateText({
+      model: haikuModel2,
       prompt,
     });
 
-    console.log('Opus:', opusResponse);
-    console.log('Sonnet:', sonnetResponse);
+    console.log('Instance 1:', response4a);
+    console.log('Instance 2:', response4b);
   } catch (error) {
     console.error('Error:', error);
   }

--- a/examples/generate-object-basic.ts
+++ b/examples/generate-object-basic.ts
@@ -32,7 +32,7 @@ async function example1_simpleObject() {
   console.log('1️⃣  Simple Object with Primitives\n');
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       name: z.string().describe('Full name of the person'),
       age: z.number().describe('Age in years'),
@@ -52,7 +52,7 @@ async function example2_arrays() {
   console.log('2️⃣  Object with Arrays\n');
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       teamName: z.string().describe('Name of the development team'),
       members: z.array(z.string()).describe('List of team member names'),
@@ -72,7 +72,7 @@ async function example3_optionalFields() {
   console.log('3️⃣  Object with Optional Fields\n');
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       productName: z.string().describe('Name of the product'),
       price: z.number().describe('Price in USD'),
@@ -96,7 +96,7 @@ async function example4_gradualComplexity() {
   // Start simple
   console.log('Step 1 - Basic user:');
   const { object: basicUser } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       username: z.string(),
       email: z.string().email(),
@@ -108,7 +108,7 @@ async function example4_gradualComplexity() {
   // Add more fields
   console.log('\nStep 2 - Enhanced user:');
   const { object: enhancedUser } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       username: z.string(),
       email: z.string().email(),
@@ -134,7 +134,7 @@ async function example5_bestPractices() {
 
   // Good: Clear descriptions and specific prompt
   const { object: good } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: z.object({
       title: z.string().describe('Article title (50-100 characters)'),
       summary: z.string().describe('Brief summary (max 200 characters)'),

--- a/examples/generate-object-constraints.ts
+++ b/examples/generate-object-constraints.ts
@@ -47,7 +47,7 @@ async function example1_enumsAndStatus() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: taskSchema,
     prompt:
       'Generate a high-priority bug task for a database performance issue, assigned to a senior developer.',
@@ -89,7 +89,7 @@ async function example2_numberConstraints() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: gameCharacterSchema,
     prompt: 'Generate a level 45 warrior character with balanced stats and moderate inventory.',
   });
@@ -156,7 +156,7 @@ async function example3_stringPatterns() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: userRegistrationSchema,
     prompt:
       'Generate a complete user registration for a software developer from San Francisco. Include GitHub username (just the username) and a complete LinkedIn profile URL like https://www.linkedin.com/in/johndoe-developer',
@@ -205,7 +205,7 @@ async function example4_arrayConstraints() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: playlistSchema,
     prompt: 'Generate a public workout playlist with 8 high-energy tracks from various genres.',
   });
@@ -273,7 +273,7 @@ async function example5_complexValidation() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: invoiceSchema,
     prompt:
       'Generate an invoice for web development services with 3 line items, sent to a US company, due in 30 days.',

--- a/examples/generate-object-nested.ts
+++ b/examples/generate-object-nested.ts
@@ -55,7 +55,7 @@ async function example1_companyStructure() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: companySchema,
     prompt:
       'Generate a structure for a mid-sized software company with 3 departments: Engineering, Product, and Marketing. Each should have 2-3 teams.',
@@ -126,7 +126,7 @@ async function example2_ecommerceOrder() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: orderSchema,
     prompt:
       'Generate an e-commerce order for a customer buying 3 different clothing items with variations. Include a discount.',
@@ -204,7 +204,7 @@ async function example3_configurationFile() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: configSchema,
     prompt:
       'Generate a production configuration for a SaaS application with comprehensive security and monitoring settings.',
@@ -289,7 +289,7 @@ async function example4_socialMediaPost() {
   });
 
   const { object } = await generateObject({
-    model: claudeCode('sonnet'),
+    model: claudeCode('haiku'),
     schema: postSchema,
     prompt:
       'Generate a viral tech announcement post with high engagement, media attachments, and top comments.',
@@ -346,7 +346,7 @@ async function example5_fileSystemStructure() {
 
   try {
     const { object } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       schema: projectSchema,
       prompt:
         'Generate a typical Next.js project file structure with src directory, showing 2 levels deep. Include common files like package.json, tsconfig.json, and directories like src, public, and components.',

--- a/examples/generate-object.ts
+++ b/examples/generate-object.ts
@@ -31,7 +31,7 @@ async function generateRecipe() {
 
   try {
     const { object: recipe } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Generate a detailed recipe for chocolate chip cookies',
       schema: recipeSchema,
     });
@@ -73,7 +73,7 @@ async function generateUserProfile() {
 
   try {
     const { object: userProfile } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt:
         'Generate a complete user profile for a software developer named Alex who loves open source',
       schema: userSchema,
@@ -104,7 +104,7 @@ async function streamAnalysis() {
     // prompt engineering requires the complete response before parsing JSON.
     // Both generateObject and streamObject wait for the full response.
     const { object } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt:
         'Analyze this product review: "This laptop is amazing! The battery life is incredible, lasting all day. The keyboard feels great to type on, though the trackpad could be more responsive. Overall, excellent value for money."',
       schema: analysisSchema,
@@ -124,7 +124,7 @@ async function generateFreeformJSON() {
 
   try {
     const { object } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt:
         'Create a JSON object representing a fictional space mission with crew members, mission objectives, and spacecraft details',
       schema: z.any(), // Allow any valid JSON

--- a/examples/hooks-callbacks.ts
+++ b/examples/hooks-callbacks.ts
@@ -37,7 +37,7 @@ async function main() {
   });
 
   const result = streamText({
-    model: provider('sonnet'),
+    model: provider('haiku'),
     prompt: 'Say hello (no tools needed).',
   });
 

--- a/examples/images.ts
+++ b/examples/images.ts
@@ -42,7 +42,7 @@ async function main() {
   const dataUrl = toDataUrl(filePath);
 
   const result = streamText({
-    model: claudeCode('sonnet', { streamingInput: 'always' }),
+    model: claudeCode('haiku', { streamingInput: 'always' }),
     messages: [
       {
         role: 'user',

--- a/examples/integration-test.ts
+++ b/examples/integration-test.ts
@@ -15,10 +15,10 @@ import { claudeCode, isAuthenticationError } from '../dist/index.js';
 //   settingSources: ['user', 'project', 'local']
 
 async function testBasicGeneration() {
-  console.log('🧪 Test 1: Basic text generation with Sonnet...');
+  console.log('🧪 Test 1: Basic text generation with Haiku...');
   try {
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Say "Hello from Claude Code Provider!" and nothing else.',
     });
 
@@ -38,7 +38,7 @@ async function testWithSystemMessage() {
   console.log('\n🧪 Test 2: Generation with system message...');
   try {
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       messages: [
         {
           role: 'system',
@@ -66,7 +66,7 @@ async function testConversation() {
   try {
     // First turn: establish context
     const { text: response1 } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       messages: [
         {
           role: 'user',
@@ -79,7 +79,7 @@ async function testConversation() {
 
     // Second turn: test memory with full history
     const { text: response2 } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       messages: [
         {
           role: 'user',
@@ -100,7 +100,7 @@ async function testConversation() {
 
     // Third turn: test deeper context
     const { text: response3 } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       messages: [
         {
           role: 'user',
@@ -130,7 +130,7 @@ async function testConversation() {
 async function testErrorHandling() {
   console.log('\n🧪 Test 4: Error handling with invalid executable path...');
   try {
-    const badClaude = claudeCode('sonnet', {
+    const badClaude = claudeCode('haiku', {
       pathToClaudeCodeExecutable: 'claude-nonexistent-binary-12345',
     });
 
@@ -156,7 +156,7 @@ async function testStreaming() {
   console.log('\n🧪 Test 5: Basic streaming...');
   try {
     const { textStream } = streamText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Count from 1 to 5, one number per line.',
     });
 

--- a/examples/limitations.ts
+++ b/examples/limitations.ts
@@ -23,7 +23,7 @@ async function main() {
 
   try {
     const { text, usage } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Write exactly 5 words.',
       // These parameters are part of the AI SDK spec but are ignored by Claude Code SDK
       temperature: 0.1, // ❌ Ignored - CLI doesn't support temperature control
@@ -60,7 +60,7 @@ async function main() {
   try {
     console.log('   Attempting generateObject()...');
     const { object } = await generateObject({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       schema: PersonSchema,
       prompt: 'Generate a person who is a software developer',
     });
@@ -85,7 +85,7 @@ async function main() {
   console.log('5. Streaming with ignored parameters:');
   try {
     const { textStream } = streamText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Count to 3',
       temperature: 0, // ❌ Still ignored in streaming mode
       maxOutputTokens: 5, // ❌ Still ignored in streaming mode

--- a/examples/long-running-tasks.ts
+++ b/examples/long-running-tasks.ts
@@ -27,7 +27,7 @@ async function withTimeout() {
 
   try {
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Analyze the implications of quantum computing on cryptography...',
       abortSignal: controller.signal,
     });
@@ -61,7 +61,7 @@ async function withUserCancellation() {
     console.log('Starting long task (will be cancelled in 2 seconds)...');
 
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Write a comprehensive guide to machine learning...',
       abortSignal: controller.signal,
     });
@@ -85,7 +85,7 @@ async function withGracefulTimeout() {
 
     try {
       const { text } = await generateText({
-        model: claudeCode('sonnet'),
+        model: claudeCode('haiku'),
         prompt: 'Explain the theory of relativity',
         abortSignal: controller.signal,
       });
@@ -140,7 +140,7 @@ async function withHelper() {
 
   try {
     const { text } = await generateText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Analyze this code for security vulnerabilities...',
       abortSignal: controller.signal,
     });
@@ -167,7 +167,7 @@ async function main() {
   console.log('- Set custom timeouts based on task complexity');
   console.log('- Always clear timeouts on success');
   console.log('- Consider retry logic for timeout scenarios');
-  console.log('- Claude Sonnet 4.5 may need 5-10 minute timeouts for complex reasoning');
+  console.log('- More complex tasks may need longer timeouts (5-10 minutes)');
 }
 
 main().catch(console.error);

--- a/examples/sdk-tools-callbacks.ts
+++ b/examples/sdk-tools-callbacks.ts
@@ -34,7 +34,7 @@ async function main() {
   });
 
   const result = streamText({
-    model: provider('sonnet'),
+    model: provider('haiku'),
     prompt: 'Use the add tool to sum 3 and 4. Provide only the number.',
   });
 

--- a/examples/streaming.ts
+++ b/examples/streaming.ts
@@ -5,7 +5,7 @@ async function main() {
   try {
     // Streaming response
     const result = streamText({
-      model: claudeCode('sonnet'),
+      model: claudeCode('haiku'),
       prompt: 'Write a haiku about programming',
     });
 

--- a/examples/tool-management.ts
+++ b/examples/tool-management.ts
@@ -28,7 +28,7 @@ async function testToolManagement() {
 
   try {
     const result1 = streamText({
-      model: defaultClaude('sonnet'),
+      model: defaultClaude('haiku'),
       prompt: 'What is 2 + 2? Just give me the number.',
     });
 
@@ -53,7 +53,7 @@ async function testToolManagement() {
 
   try {
     const result2 = streamText({
-      model: bashOnlyClaude('sonnet'),
+      model: bashOnlyClaude('haiku'),
       prompt: 'Can you show me the current date? Use the date command.',
     });
 
@@ -78,7 +78,7 @@ async function testToolManagement() {
 
   try {
     const result3 = streamText({
-      model: readOnlyClaude('sonnet'),
+      model: readOnlyClaude('haiku'),
       prompt: 'What is the capital of France? Just the city name.',
     });
 
@@ -110,7 +110,7 @@ async function testToolManagement() {
 
   try {
     const result4 = streamText({
-      model: mixedClaude('sonnet'),
+      model: mixedClaude('haiku'),
       prompt: 'What is the result of 5 * 8?',
     });
 
@@ -135,7 +135,7 @@ async function testToolManagement() {
 
   try {
     const result5 = streamText({
-      model: noToolsClaude('sonnet'),
+      model: noToolsClaude('haiku'),
       prompt: 'What programming language is this: console.log("Hello")?',
     });
 

--- a/examples/tool-streaming.ts
+++ b/examples/tool-streaming.ts
@@ -27,7 +27,7 @@ async function main() {
   const readmePath = resolve(workspaceRoot, 'README.md');
 
   const result = streamText({
-    model: claudeCode('sonnet', {
+    model: claudeCode('haiku', {
       streamingInput: 'always',
       canUseTool: allowAllTools,
       permissionMode: 'bypassPermissions',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.9",
-        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.1.20",
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.1.tgz",
-      "integrity": "sha512-+12GQktMFc5Uqz6oVjJbj7Q+GD5QDorKEKtInALKD7VleJwLlFbMYIlm4586owIV5veFvb6bAVofKn9CnYWtvw==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.20.tgz",
+      "integrity": "sha512-ONL0rppqyxjqS6XZBs+ksjtpyt9Old8QznmDJamVrz4DfisfNAXbsxDU7GpcKiOZnCPXOSRDnYSPUEwpQcxNAA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -112,6 +112,9 @@
         "@img/sharp-linux-arm64": "^0.33.5",
         "@img/sharp-linux-x64": "^0.33.5",
         "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -190,6 +193,7 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -1575,6 +1579,7 @@
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1615,6 +1620,7 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -1941,6 +1947,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2317,6 +2324,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2371,6 +2379,7 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3509,6 +3518,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4069,6 +4079,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4241,6 +4252,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4296,18 +4308,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.14.0"
-      }
-    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4332,6 +4332,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4345,8 +4346,7 @@
       "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.1.6",
@@ -4429,6 +4429,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4544,6 +4545,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4557,6 +4559,7 @@
       "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -4801,6 +4804,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "AI SDK v5 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",
@@ -71,7 +71,7 @@
   "dependencies": {
     "@ai-sdk/provider": "2.0.0",
     "@ai-sdk/provider-utils": "3.0.9",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.20",
     "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

This PR bumps the package version to 2.0.3 and updates the claude-agent-sdk dependency to the latest version (0.1.20). All examples have been updated to use the new 'haiku' model for faster execution.

## Changes

### Version & Dependencies
- 📦 Bump package version: `2.0.2` → `2.0.3`
- ⬆️ Update `@anthropic-ai/claude-agent-sdk`: `^0.1.0` → `^0.1.20` (latest)
- 🔄 Update package-lock.json with new dependency versions

### Examples & Documentation
- 🚀 Update all 18 example files to use `'haiku'` model for better performance
- 📝 Update Quick Start examples in README.md to use `'haiku'`
- 📚 Update examples/README.md code samples

## What's Included in v2.0.3

This release consolidates the following changes:

**From PR #59** (commit 3e1766a):
- ✨ feat: Add Claude 4.5 Haiku model support
- 📄 Update model documentation for Sonnet 4.5, Opus 4.1, and Haiku 4.5

**From PR #60** (commits 50111b6 & 71c8595):
- 🐛 fix: Improve truncation detection to avoid false positives on malformed JSON
- 🔧 fix: Update MinimalCallToolResult to match MCP SDK specification

**This PR**:
- 🔄 chore: Update claude-agent-sdk to latest version (0.1.20)
- ⚡ chore: Switch all examples to haiku model for optimal performance

## Validation

- ✅ Build: Clean successful
- ✅ TypeCheck: No errors
- ✅ Linting: Passed
- ✅ Format Check: All files properly formatted
- ✅ Tests: All 302 tests passed (node + edge environments)
- ✅ Examples: Validated with haiku model
  - `example:basic` - Working
  - `example:object:basic` - Working
  - `example:streaming` - Working
- ✅ Diagnostics: No errors

## Breaking Changes

None - this is a patch release with backward-compatible updates.

## Next Steps

After merge:
1. Create git tag `v2.0.3`
2. Create GitHub release with changelog
3. Publish to npm (if not automated)