### PR TITLE
fix: correct truncation detection false negatives (v2.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2025-10-19
+
+### Fixed
+
+- **Critical**: Fixed truncation detection false negatives in `isClaudeCodeTruncationError`
+  - Removed incorrect position proximity check that compared JSON parser position (full payload) against assistant text length
+  - Position comparison was comparing apples to oranges: parser position measures full JSON payload (~200+ chars) vs extracted text (~11 chars), causing `Math.abs(position - bufferedText.length) <= 16` to almost always fail
+  - This bug prevented the graceful truncation recovery path from ever running, causing all truncations to throw errors instead of returning buffered text
+  - Now relies solely on truncation indicator patterns and minimum content length (512 chars) for accurate detection
+  - Simplified logic removes unnecessary `hasUnclosedJsonStructure` helper and `POSITION_PATTERN` regex
+  - Added comprehensive documentation explaining why position checks are not feasible with current SDK layer
+  - Enhanced cross-runtime compatibility by checking error name for cross-realm SyntaxError instances
+  - Added additional truncation indicator patterns: "unexpected eof", "end of file", "unterminated string constant"
+
+### Changed
+
+- Improved documentation in `isClaudeCodeTruncationError` function explaining truncation detection strategy
+- Lowered minimum truncation length threshold from 1024 to 512 characters for better recovery on shorter responses
+- Updated warning message to reference "SDK" instead of "CLI" for consistency with v2.x terminology
+- Clarified that content length is measured in UTF-16 code units, not byte length
+
 ## [2.0.4] - 2025-10-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -193,7 +193,6 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -1579,7 +1578,6 @@
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1620,7 +1618,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -1947,7 +1944,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2324,7 +2320,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2379,7 +2374,6 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3518,7 +3512,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4079,7 +4072,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4252,7 +4244,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4332,21 +4323,12 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.1.6",
@@ -4429,7 +4411,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4545,7 +4526,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4559,7 +4539,6 @@
       "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -4803,8 +4782,8 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "AI SDK v5 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Critical Bug Fix

Fixes truncation detection bug reported by chatgpt-codex-connector bot that prevented graceful truncation recovery from ever running.

## Problem

The `isClaudeCodeTruncationError` function compared JSON parser position (full payload) against assistant text length:
- **JSON payload**: `{"type":"assistant","message":{...}}` (~200+ chars)
- **Assistant text**: `"Hello world"` (~11 chars)
- **Result**: `Math.abs(position - bufferedText.length) <= 16` **almost always failed**
- **Impact**: All truncations threw errors instead of returning buffered text with `finishReason: 'length'`

## Solution

- ✅ Removed incorrect position proximity check
- ✅ Removed unnecessary `hasUnclosedJsonStructure` helper and `POSITION_PATTERN` regex
- ✅ Rely on truncation indicator patterns + minimum content length (512 chars)
- ✅ Enhanced cross-runtime compatibility with error name check
- ✅ Added additional truncation indicators: "unexpected eof", "end of file", "unterminated string constant"
- ✅ Updated terminology from "CLI" to "SDK"
- ✅ Comprehensive documentation explaining detection strategy

## Testing

- ✅ All 302 tests passing (node + edge environments)
- ✅ Build successful
- ✅ Typecheck passed
- ✅ Lint passed (101 warnings, 0 errors)
- ✅ Format check passed

## Files Changed

```
CHANGELOG.md                      | 18 +++++
package-lock.json                 | 10 +--
package.json                      |  2 +-
src/claude-code-language-model.ts | 64 ++++-----
4 files changed, 64 insertions(+), 90 deletions(-)
```

## Related

- Reported by: chatgpt-codex-connector bot on PR #66
- Will be backported to v1 branch as v1.2.2