### PR TITLE
chore: bump @anthropic-ai/claude-agent-sdk to ^0.1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4] - 2025-12-04
+
+### Changed
+
+- **Updated Claude Agent SDK to ^0.1.59** - Fixes Apple notarization failures for macOS Electron apps
+  - The SDK removed the bundled JetBrains plugin which contained unsigned macOS native binaries (`jansi-2.4.1.jar`)
+  - This eliminates notarization errors for macOS apps that include the SDK as a dependency
+  - See [claude-agent-sdk-typescript#91](https://github.com/anthropics/claude-agent-sdk-typescript/issues/91) for details
+
 ## [2.2.3] - 2025-11-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.9",
-        "@anthropic-ai/claude-agent-sdk": "^0.1.51"
+        "@anthropic-ai/claude-agent-sdk": "^0.1.59"
       },
       "devDependencies": {
         "@edge-runtime/vm": "5.0.0",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.1.51",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.51.tgz",
-      "integrity": "sha512-ob45qPyQxHXjr2xe6MmQb8QMs5LytNfzclKyDqckcrndAPg0jpZ8J0diCJlzHK5akPrCcQonSQfjVNezcBPkVA==",
+      "version": "0.1.59",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.59.tgz",
+      "integrity": "sha512-9TMxQCkIOd9W3c+owLtTW7d1ZgWeYoz1tbUwqz1TiKJTZmsmAFHUfXebQsJBZ+W15g6msqA6ln9yYxOKlNnlGw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -129,6 +129,8 @@
         "@img/sharp-linux-arm": "^0.33.5",
         "@img/sharp-linux-arm64": "^0.33.5",
         "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
         "@img/sharp-win32-x64": "^0.33.5"
       },
       "peerDependencies": {
@@ -1062,6 +1064,38 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
@@ -1126,6 +1160,50 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-win32-x64": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "AI SDK v5 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",
@@ -72,7 +72,7 @@
   "dependencies": {
     "@ai-sdk/provider": "2.0.0",
     "@ai-sdk/provider-utils": "3.0.9",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.51"
+    "@anthropic-ai/claude-agent-sdk": "^0.1.59"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/claude-agent-sdk` from `^0.1.51` to `^0.1.59`
- Bumps package version to `2.2.4`

This fixes Apple notarization failures for macOS Electron apps that include this package as a dependency. The SDK team resolved this by removing the bundled JetBrains plugin which contained unsigned macOS native binaries (`jansi-2.4.1.jar`).

Resolves: anthropics/claude-agent-sdk-typescript#91

## Verified

```
# Old (0.1.51) - problematic JetBrains plugin present:
vendor/claude-code-jetbrains-plugin/lib/jansi-2.4.1.jar

# New (0.1.59) - JetBrains plugin removed entirely:
vendor/ripgrep/  (only)
```

## Test plan

- [x] `npm install` succeeds
- [x] Package builds successfully
- [x] Verified `jansi-2.4.1.jar` no longer present in SDK
- [ ] Verify macOS Electron app notarization passes (if applicable)