### PR TITLE
feat!: migrate to AI SDK v6 (LanguageModelV3/ProviderV3)

### DIFF
--- a/examples/conversation-history.ts
+++ b/examples/conversation-history.ts
@@ -10,13 +10,13 @@ import { claudeCode } from '../dist/index.js';
 // To restore old behavior, set:
 //   systemPrompt: { type: 'preset', preset: 'claude_code' }
 //   settingSources: ['user', 'project', 'local']
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 
 async function testConversation() {
   console.log('🧪 Testing conversation with message history...');
 
   const model = claudeCode('opus');
-  const messages: CoreMessage[] = [];
+  const messages: ModelMessage[] = [];
 
   // First turn
   console.log(`\n1️⃣ First turn...`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "2.2.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.9",
+        "@ai-sdk/provider": "^3.0.0-beta",
+        "@ai-sdk/provider-utils": "^4.0.0-beta",
         "@anthropic-ai/claude-agent-sdk": "^0.1.59"
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
         "@typescript-eslint/eslint-plugin": "8.34.0",
         "@typescript-eslint/parser": "8.34.0",
         "@vitest/coverage-v8": "^3.2.4",
-        "ai": "5.0.101",
+        "ai": "^6.0.0-beta",
         "eslint": "9.28.0",
         "globals": "16.2.0",
         "prettier": "^3.6.2",
@@ -37,14 +37,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.15.tgz",
-      "integrity": "sha512-i1YVKzC1dg9LGvt+GthhD7NlRhz9J4+ZRj3KELU14IZ/MHPsOBiFeEoCCIDLR+3tqT8/+5nIsK3eZ7DFRfMfdw==",
+      "version": "2.0.0-beta.73",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.0-beta.73.tgz",
+      "integrity": "sha512-fVuJ4emiymdSmlB7IiRfSyaWZm3+zqBUf+KYJiYrlpQEXGZPMTgo2xNhVlyb0oWzFyFBnbIChYBNZgzFs48ckQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.17",
+        "@ai-sdk/provider": "3.0.0-beta.25",
+        "@ai-sdk/provider-utils": "4.0.0-beta.44",
         "@vercel/oidc": "3.0.5"
       },
       "engines": {
@@ -54,28 +54,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz",
-      "integrity": "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+      "version": "3.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0-beta.25.tgz",
+      "integrity": "sha512-DE7vSHX29Tgw3VX8oPuIJ6yD0nCKor98LvpUX1SkUCqi4UNKQeOr0X93RaRciINRaDQwGcDVRRuGU7RONYDIfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -85,20 +67,34 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.9.tgz",
-      "integrity": "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==",
+      "version": "4.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.0-beta.44.tgz",
+      "integrity": "sha512-eV5Ubq01zT9rQnJaf6nCQKgpQgEiOzWzlXGWRFTZGDfVn/+09GRJ/gyLXhliwUjTgaNLTZvTdp9HahTigENn4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider": "3.0.0-beta.25",
         "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.5"
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
+        "@valibot/to-json-schema": "^1.3.0",
+        "arktype": "^2.1.22",
+        "effect": "^3.18.4",
+        "zod": "^3.25.76 || ^4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2068,34 +2064,16 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.101",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.101.tgz",
-      "integrity": "sha512-/P4fgs2PGYTBaZi192YkPikOudsl9vccA65F7J7LvoNTOoP5kh1yAsJPsKAy6FXU32bAngai7ft1UDyC3u7z5g==",
+      "version": "6.0.0-beta.138",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.0-beta.138.tgz",
+      "integrity": "sha512-aS+XzvnUXUx4irNY/UH0tM+yTIMGgWsMDFKiwWHVKaPhKvdRoJA+KoVqW+/EzBU4zI+v+OriNKCMKz3kW++7kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.15",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.17",
+        "@ai-sdk/gateway": "2.0.0-beta.73",
+        "@ai-sdk/provider": "3.0.0-beta.25",
+        "@ai-sdk/provider-utils": "4.0.0-beta.44",
         "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz",
-      "integrity": "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "2.2.4",
-  "description": "AI SDK v5 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
+  "version": "3.0.0",
+  "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",
     "claude-agent-sdk",
@@ -70,8 +70,8 @@
     "example:all": "npm run build && npm run example:basic && npm run example:streaming && npm run example:conversation && npm run example:config && npm run example:object:basic && npm run example:object:nested && npm run example:object:constraints && npm run example:tools && npm run example:timeout"
   },
   "dependencies": {
-    "@ai-sdk/provider": "2.0.0",
-    "@ai-sdk/provider-utils": "3.0.9",
+    "@ai-sdk/provider": "^3.0.0-beta",
+    "@ai-sdk/provider-utils": "^4.0.0-beta",
     "@anthropic-ai/claude-agent-sdk": "^0.1.59"
   },
   "devDependencies": {
@@ -81,7 +81,7 @@
     "@typescript-eslint/eslint-plugin": "8.34.0",
     "@typescript-eslint/parser": "8.34.0",
     "@vitest/coverage-v8": "^3.2.4",
-    "ai": "5.0.101",
+    "ai": "^6.0.0-beta",
     "eslint": "9.28.0",
     "globals": "16.2.0",
     "prettier": "^3.6.2",

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
-import type { LanguageModelV2StreamPart } from '@ai-sdk/provider';
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
 
 // Extend stream part union locally to include provider-specific 'tool-error'
 type ToolErrorPart = {
@@ -11,7 +11,7 @@ type ToolErrorPart = {
   providerExecuted: true;
   providerMetadata?: Record<string, unknown>;
 };
-type ExtendedStreamPart = LanguageModelV2StreamPart | ToolErrorPart;
+type ExtendedStreamPart = LanguageModelV3StreamPart | ToolErrorPart;
 
 // Mock the SDK module with factory function
 vi.mock('@anthropic-ai/claude-agent-sdk', () => {
@@ -1111,8 +1111,8 @@ describe('ClaudeCodeLanguageModel', () => {
         type: 'stream-start',
         warnings: expect.arrayContaining([
           expect.objectContaining({
-            type: 'unsupported-setting',
-            setting: 'temperature',
+            type: 'unsupported',
+            feature: 'temperature',
           }),
         ]),
       });
@@ -1146,8 +1146,8 @@ describe('ClaudeCodeLanguageModel', () => {
       // Warnings are now included in the stream-start event
       expect(chunks[0].warnings).toHaveLength(1);
       expect(chunks[0].warnings?.[0]).toMatchObject({
-        type: 'unsupported-setting',
-        setting: 'temperature',
+        type: 'unsupported',
+        feature: 'temperature',
       });
 
       // Verify outputFormat was passed to SDK
@@ -1250,7 +1250,7 @@ describe('ClaudeCodeLanguageModel', () => {
       // Should emit: stream-start (with warning), text-start, text-delta, text-end, finish
       expect(chunks).toHaveLength(5);
 
-      // Verify unsupported-setting warning is emitted
+      // Verify unsupported warning is emitted
       expect(chunks[0]).toMatchObject({
         type: 'stream-start',
       });
@@ -1258,8 +1258,8 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(streamStartWarnings).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: 'unsupported-setting',
-            setting: 'responseFormat',
+            type: 'unsupported',
+            feature: 'responseFormat',
             details: expect.stringContaining('requires a schema'),
           }),
         ])
@@ -2097,7 +2097,7 @@ describe('ClaudeCodeLanguageModel', () => {
         responseFormat: { type: 'json' },
       } as any);
 
-      const events: LanguageModelV2StreamPart[] = [];
+      const events: LanguageModelV3StreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2, ProviderV2 } from '@ai-sdk/provider';
+import type { LanguageModelV3, ProviderV3 } from '@ai-sdk/provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { ClaudeCodeLanguageModel, type ClaudeCodeModelId } from './claude-code-language-model.js';
 import type { ClaudeCodeSettings } from './types.js';
@@ -6,7 +6,7 @@ import { validateSettings } from './validation.js';
 import { getLogger } from './logger.js';
 
 /**
- * Claude Code provider interface that extends the AI SDK's ProviderV1.
+ * Claude Code provider interface that extends the AI SDK's ProviderV3.
  * Provides methods to create language models for interacting with Claude via the CLI.
  *
  * @example
@@ -21,7 +21,7 @@ import { getLogger } from './logger.js';
  * const languageModel = claudeCode.languageModel('opus', { maxTurns: 10 });
  * ```
  */
-export interface ClaudeCodeProvider extends ProviderV2 {
+export interface ClaudeCodeProvider extends ProviderV3 {
   /**
    * Creates a language model instance for the specified model ID.
    * This is a shorthand for calling `languageModel()`.
@@ -30,7 +30,7 @@ export interface ClaudeCodeProvider extends ProviderV2 {
    * @param settings - Optional settings to configure the model
    * @returns A language model instance
    */
-  (modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV2;
+  (modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV3;
 
   /**
    * Creates a language model instance for text generation.
@@ -39,7 +39,7 @@ export interface ClaudeCodeProvider extends ProviderV2 {
    * @param settings - Optional settings to configure the model
    * @returns A language model instance
    */
-  languageModel(modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV2;
+  languageModel(modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV3;
 
   /**
    * Alias for `languageModel()` to maintain compatibility with AI SDK patterns.
@@ -48,7 +48,7 @@ export interface ClaudeCodeProvider extends ProviderV2 {
    * @param settings - Optional settings to configure the model
    * @returns A language model instance
    */
-  chat(modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV2;
+  chat(modelId: ClaudeCodeModelId, settings?: ClaudeCodeSettings): LanguageModelV3;
 
   imageModel(modelId: string): never;
 }
@@ -112,7 +112,7 @@ export function createClaudeCode(options: ClaudeCodeProviderSettings = {}): Clau
   const createModel = (
     modelId: ClaudeCodeModelId,
     settings: ClaudeCodeSettings = {}
-  ): LanguageModelV2 => {
+  ): LanguageModelV3 => {
     const mergedSettings = {
       ...options.defaultSettings,
       ...settings,
@@ -141,12 +141,13 @@ export function createClaudeCode(options: ClaudeCodeProviderSettings = {}): Clau
 
   provider.languageModel = createModel;
   provider.chat = createModel; // Alias for languageModel
+  provider.specificationVersion = 'v3' as const;
 
-  // Add textEmbeddingModel method that throws NoSuchModelError
-  provider.textEmbeddingModel = (modelId: string) => {
+  // Add embeddingModel method that throws NoSuchModelError
+  provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({
       modelId,
-      modelType: 'textEmbeddingModel',
+      modelType: 'embeddingModel',
     });
   };
 

--- a/src/convert-to-claude-code-messages.images.test.ts
+++ b/src/convert-to-claude-code-messages.images.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import { convertToClaudeCodeMessages } from './convert-to-claude-code-messages.js';
 
 describe('convertToClaudeCodeMessages (images)', () => {
@@ -12,7 +12,7 @@ describe('convertToClaudeCodeMessages (images)', () => {
           { type: 'image', image: 'data:image/png;base64,aGVsbG8=' },
         ],
       },
-    ] as CoreMessage[];
+    ] as ModelMessage[];
 
     const result = convertToClaudeCodeMessages(prompt);
 
@@ -42,7 +42,7 @@ describe('convertToClaudeCodeMessages (images)', () => {
           { type: 'image', image: { data: 'AQID', mimeType: 'image/jpeg' } },
         ],
       },
-    ] as CoreMessage[];
+    ] as ModelMessage[];
 
     const result = convertToClaudeCodeMessages(prompt);
 
@@ -67,7 +67,7 @@ describe('convertToClaudeCodeMessages (images)', () => {
           { type: 'image', image: 'https://example.com/image.png' },
         ],
       },
-    ] as CoreMessage[];
+    ] as ModelMessage[];
 
     const result = convertToClaudeCodeMessages(prompt);
 
@@ -87,7 +87,7 @@ describe('convertToClaudeCodeMessages (images)', () => {
           { type: 'file', mediaType: 'image/png', data: 'aGVsbG8=' },
         ],
       },
-    ] as CoreMessage[];
+    ] as ModelMessage[];
 
     const result = convertToClaudeCodeMessages(prompt);
 

--- a/src/convert-to-claude-code-messages.test.ts
+++ b/src/convert-to-claude-code-messages.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { convertToClaudeCodeMessages } from './convert-to-claude-code-messages.js';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 
 describe('convertToClaudeCodeMessages', () => {
   it('should convert a simple user message', () => {
     const result = convertToClaudeCodeMessages([
       { role: 'user', content: 'Hello, Claude!' },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('Human: Hello, Claude!');
     expect(result.systemPrompt).toBeUndefined();
@@ -15,7 +15,7 @@ describe('convertToClaudeCodeMessages', () => {
   it('should convert a simple assistant message', () => {
     const result = convertToClaudeCodeMessages([
       { role: 'assistant', content: 'Hello! How can I help you?' },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('Assistant: Hello! How can I help you?');
     expect(result.systemPrompt).toBeUndefined();
@@ -24,7 +24,7 @@ describe('convertToClaudeCodeMessages', () => {
   it('should handle system message', () => {
     const result = convertToClaudeCodeMessages([
       { role: 'system', content: 'You are a helpful assistant.' },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('You are a helpful assistant.');
     expect(result.systemPrompt).toBe('You are a helpful assistant.');
@@ -36,7 +36,7 @@ describe('convertToClaudeCodeMessages', () => {
       { role: 'user', content: 'What is 2+2?' },
       { role: 'assistant', content: '2+2 equals 4.' },
       { role: 'user', content: 'Thanks!' },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.systemPrompt).toBe('Be helpful.');
     expect(result.messagesPrompt).toBe(
@@ -54,7 +54,7 @@ describe('convertToClaudeCodeMessages', () => {
           { type: 'text', text: 'world!' },
         ],
       },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('Human: Hello\n, \nworld!');
   });
@@ -68,7 +68,7 @@ describe('convertToClaudeCodeMessages', () => {
           { type: 'image', image: new Uint8Array([1, 2, 3]) },
         ],
       },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.warnings).toBeDefined();
     expect(result.warnings).toContain('Unable to convert image content; supply base64/data URLs.');
@@ -133,7 +133,7 @@ describe('convertToClaudeCodeMessages', () => {
         role: 'user',
         content: [],
       },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('');
   });
@@ -144,7 +144,7 @@ describe('convertToClaudeCodeMessages', () => {
         role: 'user',
         content: [{ type: 'text', text: undefined as any }],
       },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe('');
   });
@@ -184,7 +184,7 @@ describe('convertToClaudeCodeMessages', () => {
       { role: 'user', content: 'Second message' },
       { role: 'assistant', content: 'Response' },
       { role: 'user', content: 'Third message' },
-    ] as CoreMessage[]);
+    ] as ModelMessage[]);
 
     expect(result.messagesPrompt).toBe(
       'Human: First message\n\nHuman: Second message\n\nAssistant: Response\n\nHuman: Third message'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export type { ClaudeCodeProvider, ClaudeCodeProviderSettings } from './claude-co
 
 /**
  * Language model implementation for Claude Code.
- * This class implements the AI SDK's LanguageModelV2 interface.
+ * This class implements the AI SDK's LanguageModelV3 interface.
  */
 export { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
 

--- a/src/map-claude-code-finish-reason.ts
+++ b/src/map-claude-code-finish-reason.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2FinishReason } from '@ai-sdk/provider';
+import type { LanguageModelV3FinishReason } from '@ai-sdk/provider';
 
 /**
  * Maps Claude Code SDK result subtypes to AI SDK finish reasons.
@@ -19,7 +19,7 @@ import type { LanguageModelV2FinishReason } from '@ai-sdk/provider';
  * - 'error_during_execution' -> 'error' (execution error)
  * - default -> 'stop' (unknown subtypes treated as normal completion)
  */
-export function mapClaudeCodeFinishReason(subtype?: string): LanguageModelV2FinishReason {
+export function mapClaudeCodeFinishReason(subtype?: string): LanguageModelV3FinishReason {
   switch (subtype) {
     case 'success':
       return 'stop';


### PR DESCRIPTION
## Summary

- Migrate from AI SDK v5 to v6 beta
- Update to `@ai-sdk/provider` ^3.0.0-beta and `ai` ^6.0.0-beta
- Version bumped to 3.0.0

## Breaking Changes

- `LanguageModelV2` → `LanguageModelV3`
- `ProviderV2` → `ProviderV3`
- `specificationVersion` changed from `'v2'` to `'v3'`
- Warning format: `'unsupported-setting'` → `'unsupported'` with `feature` field
- `CoreMessage` → `ModelMessage`
- `textEmbeddingModel()` → `embeddingModel()`
- `SharedV3Warning` replaces `LanguageModelV2CallWarning`
- Handle new `ToolResultOutput` union types (`execution-denied`, `error-text`, `error-json`, `content`)

## Test plan

- [x] All 274 tests passing
- [x] Build succeeds with full type checking
- [x] Examples verified working (basic, streaming, object generation)