### PR TITLE
More thorough error handling

### DIFF
--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
-import { getErrorMetadata } from './errors.js';
+import { getErrorMetadata, isAuthenticationError } from './errors.js';
 import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
 
 // Extend stream part union locally to include provider-specific 'tool-error'
@@ -448,6 +448,150 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(metadata?.exitCode).toBe(1);
     });
 
+    it('should detect /login pattern as authentication error', async () => {
+      vi.mocked(mockQuery).mockImplementation(() => {
+        throw new Error('Please run /login to authenticate');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(isAuthenticationError(thrownError)).toBe(true);
+    });
+
+    it('should detect invalid api key pattern as authentication error', async () => {
+      vi.mocked(mockQuery).mockImplementation(() => {
+        throw new Error('Invalid API key provided');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(isAuthenticationError(thrownError)).toBe(true);
+    });
+
+    it('should throw error when result message has is_error flag', async () => {
+      // This simulates the actual CLI response when unauthenticated
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'result',
+            subtype: 'success', // CLI returns success subtype even on error
+            is_error: true,
+            result: 'Invalid API key · Please run /login',
+            session_id: 'test-session',
+            total_cost_usd: 0,
+            usage: { input_tokens: 0, output_tokens: 0 },
+          };
+        },
+      };
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(thrownError).toBeInstanceOf(Error);
+      // The error message should contain the original error content
+      expect((thrownError as Error).message).toContain('Invalid API key');
+      // The error should be converted to an auth error (contains /login pattern)
+      expect(isAuthenticationError(thrownError)).toBe(true);
+    });
+
+    it('should use default message when is_error is true but result field is missing', async () => {
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'result',
+            subtype: 'success',
+            is_error: true,
+            // No result field
+            session_id: 'test-session',
+          };
+        },
+      };
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(thrownError).toBeInstanceOf(Error);
+      expect((thrownError as Error).message).toBe('Claude Code CLI returned an error');
+    });
+
+    it('should include stderr in error metadata when is_error is true', async () => {
+      const stderrCallback = vi.fn();
+      const modelWithStderr = new ClaudeCodeLanguageModel({
+        id: 'sonnet',
+        settings: { stderr: stderrCallback },
+      });
+
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        // Simulate stderr being emitted before the is_error result
+        if (options?.stderr) {
+          options.stderr('Warning: some diagnostic info\n');
+        }
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'result',
+              subtype: 'success',
+              is_error: true,
+              result: 'Some error occurred',
+              session_id: 'test-session',
+            };
+          },
+        } as any;
+      });
+
+      let thrownError: unknown;
+      try {
+        await modelWithStderr.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      // Verify stderr callback was invoked
+      expect(stderrCallback).toHaveBeenCalledWith('Warning: some diagnostic info\n');
+
+      // Verify error was thrown
+      expect(thrownError).toBeDefined();
+      expect((thrownError as Error).message).toBe('Some error occurred');
+
+      // Verify error metadata includes collected stderr
+      const metadata = getErrorMetadata(thrownError);
+      expect(metadata?.stderr).toBe('Warning: some diagnostic info\n');
+    });
+
     it('recovers from CLI truncation errors and returns buffered text', async () => {
       const repeatedTasks = Array.from({ length: 400 }, (_, i) => `task-${i}`).join('","');
       const partialResponse = `{"tasks": ["${repeatedTasks}`;
@@ -619,6 +763,50 @@ describe('ClaudeCodeLanguageModel', () => {
           outputTokens: { total: 5 },
         },
       });
+    });
+
+    it('should emit error chunk when result message has is_error flag in streaming', async () => {
+      // This simulates the actual CLI response when unauthenticated during streaming
+      const mockResponse = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'result',
+            subtype: 'success', // CLI returns success subtype even on error
+            is_error: true,
+            result: 'Invalid API key · Please run /login',
+            session_id: 'test-session',
+            total_cost_usd: 0,
+            usage: { input_tokens: 0, output_tokens: 0 },
+          };
+        },
+      };
+      vi.mocked(mockQuery).mockReturnValue(mockResponse as any);
+
+      const result = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+      });
+
+      const chunks: ExtendedStreamPart[] = [];
+      const reader = result.stream.getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      // Should emit stream-start and then error
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0]).toMatchObject({
+        type: 'stream-start',
+      });
+      expect(chunks[1]).toMatchObject({
+        type: 'error',
+      });
+      // The error should contain the auth message
+      expect((chunks[1] as any).error.message).toContain('Invalid API key');
+      // The error should be converted to an auth error (contains /login pattern)
+      expect(isAuthenticationError((chunks[1] as any).error)).toBe(true);
     });
 
     describe('stream_event handling (includePartialMessages)', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, defineWorkspace } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
 // Define workspace with multiple environments
 export default defineConfig({


### PR DESCRIPTION
Hey,

I had to add some more error handling for my use case (passing OAuth keys inline and often having auth errors) as I kept getting generic exit 1 errors with no further info.

## How It Works

When the SDK spawns the Claude CLI process:

1. The stderr callback receives data during execution (e.g., auth error messages)
2. We collect this data in a local variable
3. If the process fails quickly (before completing), the SDK throws an error
4. We include the collected stderr in the error metadata, even if the SDK didn't

Additionally, the CLI may return a successful JSON response with `is_error: true` for auth failures:

```json
{
  "type": "result",
  "subtype": "success",
  "is_error": true,
  "result": "Invalid API key · Please run /login"
}
```

We now detect this pattern and convert it to a proper authentication error.

## Changes Made

### 1. src/claude-code-language-model.ts

Auth error pattern detection (line 726):
- Added /login pattern (CLI returns "Please run /login")
- Added invalid api key pattern

handleClaudeCodeError method (line 697):
- Added optional collectedStderr parameter
- Uses SDK's error.stderr if available, otherwise falls back to collectedStderr

createQueryOptions method (line 609):
- Added optional stderrCollector parameter
- Wraps the user's stderr callback to both collect data AND call the original callback

doGenerate method (line 822):
- Creates a stderr collector before calling createQueryOptions
- Passes collected stderr to handleClaudeCodeError on errors
- Handles is_error: true in result messages (line 908-916)

doStream method (line 1026):
- Same pattern as doGenerate
- Handles is_error: true in streaming result messages (line 1517-1525)

### 2. src/claude-code-language-model.test.ts

New test cases:

- should capture stderr from callback when SDK throws error - Verifies user's stderr callback is still called and error metadata includes collected stderr
- should detect /login pattern as authentication error - Tests new auth pattern
- should detect invalid api key pattern as authentication error - Tests new auth pattern
- should throw error when result message has is_error flag - Tests is_error handling in doGenerate
- should use default message when is_error is true but result field is missing - Edge case
- should include stderr in error metadata when is_error is true - Tests stderr collection with is_error
- should emit error chunk when result message has is_error flag in streaming - Tests is_error handling in doStream

## Misc

This is the raw output of a test:

```sh
bunx @anthropic-ai/claude-code --output-format json 2>/tmp/stderr.txt; echo "=== STDOUT above, STDERR below ==="; cat /tmp/stderr.txt')
  ⎿  {                                                      
       "type": "result",
       "subtype": "success",
       "is_error": true,
       "duration_ms": 95,
       "duration_api_ms": 0,
       "num_turns": 1,
       "result": "Invalid API key · Please run /login",
       "session_id": "455860b1-ee77-4e4b-abd2-dab2173d8350",
       "total_cost_usd": 0,
       "usage": {
         "input_tokens": 0,
         "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 0,
         "output_tokens": 0,
         "server_tool_use": {
           "web_search_requests": 0,
           "web_fetch_requests": 0
         },
         "service_tier": "standard",
         "cache_creation": {
           "ephemeral_1h_input_tokens": 0,
           "ephemeral_5m_input_tokens": 0
         }
       },
       "modelUsage": {},
       "permission_denials": [],
       "uuid": "6f8bbcae-2dcd-4c24-a03d-e67864223d00"
     }
     === STDOUT above, STDERR below ===
     Resolving dependencies
     Resolved, downloaded and extracted [2]
     Saved lockfile 
```