### PR TITLE
chore: release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-01-05
+
+### Added
+
+- **Agent SDK options passthrough (guarded)** - Added `sdkOptions` escape hatch for passing through Agent SDK `Options`, with blocked internal fields (`model`, `abortController`, `prompt`, `outputFormat`)
+- **Expanded Agent SDK settings** - Exposed `betas`, `allowDangerouslySkipPermissions`, `enableFileCheckpointing`, `maxBudgetUsd`, `plugins`, `resumeSessionAt`, `sandbox`, and `tools` in `ClaudeCodeSettings`
+- **sdkOptions tests** - Added coverage for env/stderr merge preservation and sdkOptions override behavior
+
+### Changed
+
+- **Session resume consistency** - `resume` now stays in sync between query options and streaming prompt session IDs
+
 ## [3.0.1] - 2025-12-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Summary
- bump version to 3.1.0
- document Agent SDK option passthrough release in CHANGELOG

## Testing
- not run (release-only metadata changes)
