### PR TITLE
chore(release): bump to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Security
+
+### Fixed
+
+## [3.3.0] - 2026-01-15
+
+### Added
+
 - **MCP tool result normalization** - Handles MCP content format (`[{type: 'text', text: '...'}]`) in tool results, automatically extracting and parsing JSON content from text blocks while preserving non-text content blocks (images, resources, audio) unchanged
 - **Tool result stream truncation** - Adds `maxToolResultSize` (default 10k) to cap tool results sent to the client stream and truncates oversized `rawResult` metadata to avoid stream bloat
 - **Subagent hierarchy tracking** - Tool stream events now include `providerMetadata['claude-code'].parentToolCallId` to expose Task/subagent parent-child relationships; Task tools always emit null, and parallel Task parents remain null when ambiguous

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.1.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
@@ -33,7 +33,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.24.1 || ^4.0.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Summary
- bump package version to 3.3.0
- move Unreleased changelog entries into 3.3.0 section
- update package-lock after version bump

## Testing
- not run (version/changelog changes only)