### PR TITLE
feat: expose modelUsage in providerMetadata

### DIFF
--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1058,6 +1058,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     let wasTruncated = false;
     let costUsd: number | undefined;
     let durationMs: number | undefined;
+    let modelUsage: Record<string, unknown> | undefined;
     const warnings: SharedV3Warning[] = this.generateAllWarnings(options, messagesPrompt);
 
     // Add warnings from message conversion
@@ -1129,6 +1130,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
           this.setSessionId(message.session_id);
           costUsd = message.total_cost_usd;
           durationMs = message.duration_ms;
+          modelUsage = message.modelUsage;
 
           // Handle is_error flag in result message (e.g., auth failures)
           // The CLI returns successful JSON with is_error: true and error message in result field
@@ -1227,6 +1229,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
           ...(this.sessionId !== undefined && { sessionId: this.sessionId }),
           ...(costUsd !== undefined && { costUsd }),
           ...(durationMs !== undefined && { durationMs }),
+          ...(modelUsage !== undefined && { modelUsage: modelUsage as unknown as JSONValue }),
           ...(wasTruncated && { truncated: true }),
         },
       },
@@ -2238,6 +2241,9 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                       costUsd: message.total_cost_usd,
                     }),
                     ...(message.duration_ms !== undefined && { durationMs: message.duration_ms }),
+                    ...(message.modelUsage !== undefined && {
+                      modelUsage: message.modelUsage as unknown as JSONValue,
+                    }),
                     // JSON validation warnings are collected during streaming and included
                     // in providerMetadata since the AI SDK's finish event doesn't support
                     // a top-level warnings field (unlike stream-start which was already emitted)


### PR DESCRIPTION
## Summary
  - Expose modelUsage field in providerMetadata["claude-code"] for
  both doGenerate() and doStream() methods
  - Enables access to per-model usage metrics from the Claude Agent
  SDK
  - Enables seeing the context window

 ## Details

  The modelUsage field provides authoritative per-model usage data,
  suitable for billing purposes. This is especially useful when using
  multiple models (e.g., Haiku for subagents, Opus for the main
  agent).

  The field is a map of model name to ModelUsage:
```
  type ModelUsage = {
    inputTokens: number;
    outputTokens: number;
    cacheReadInputTokens: number;
    cacheCreationInputTokens: number;
    webSearchRequests: number;
    costUSD: number;
    contextWindow: number;
  };
```
  ## Documentation:
  https://platform.claude.com/docs/en/agent-sdk/cost-tracking

  ## Changes

  - Added modelUsage capture from SDK result messages
  - Included modelUsage in provider metadata response (conditionally,
  only when available)
  - Added 4 tests covering both presence and absence of modelUsage in
  doGenerate/doStream

  ## Test plan

  - npm run typecheck passes
  - npm test passes (344 tests)
  - npm run build succeeds