### PR TITLE
chore: release v3.3.4 — update claude-agent-sdk and add mid-session injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Mid-session message injection** - Added `onStreamStart` and `MessageInjector` to enable injecting messages during active sessions, plus an example and tests covering delivery tracking and recovery.
-
 ### Security
 
 ### Fixed
+
+## [3.3.4] - 2026-01-28
+
+### Added
+
+- **Mid-session message injection** - Added `onStreamStart` and `MessageInjector` to enable injecting messages during active sessions, plus an example and tests covering delivery tracking and recovery.
+
+### Changed
+
+- **Updated Claude Agent SDK to ^0.2.23** - Bumped `@anthropic-ai/claude-agent-sdk` from `^0.2.9` to `^0.2.23` to pick up the latest bug fixes and improvements
 
 ## [3.3.3] - 2026-01-23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "@ai-sdk/provider-utils": "^4.0.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.2.9"
+        "@anthropic-ai/claude-agent-sdk": "^0.2.23"
       },
       "devDependencies": {
         "@edge-runtime/vm": "5.0.0",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.9.tgz",
-      "integrity": "sha512-b4JD6ZKCZeVDqpWBnb+zJISWi3HzlweNlV7Oy/uo5G2XAfUV2M5AJ/tomKZCvZsvmr1fYbmmfyde3GL2h0pksA==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.23.tgz",
+      "integrity": "sha512-pkY8vQu4cVoy43JaGNlnV7cl7RiaBjwt5kwiYucLqs37B/EUmvcM2LK44CgC9YyPSM0OTTAXaTYy7Bp4hje4UQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",
@@ -73,7 +73,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^3.0.0",
     "@ai-sdk/provider-utils": "^4.0.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.9"
+    "@anthropic-ai/claude-agent-sdk": "^0.2.23"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",


### PR DESCRIPTION
## Changes

### Added
- **Mid-session message injection** — `onStreamStart` and `MessageInjector` to enable injecting messages during active sessions, plus an example and tests covering delivery tracking and recovery.

### Changed
- **Updated Claude Agent SDK to ^0.2.23** — Bumped `@anthropic-ai/claude-agent-sdk` from `^0.2.9` to `^0.2.23` to pick up the latest bug fixes and improvements.

### Release
- Bumped package version from `3.3.3` → `3.3.4`
- Updated CHANGELOG.md with 3.3.4 entry

---

All lint, typecheck, and 368 tests pass (node + edge).