### PR TITLE
chore: bump version to 3.4.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.4.4] - 2026-03-10
+
+### Fixed
+
+- **Interrupted text blocks** - Prevent duplicate `text-end` events when a text block is closed early by a tool-use block, reasoning block, or assistant tool message before its later `content_block_stop` arrives.
+
 ## [3.4.3] - 2026-03-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Summary
- bump package version from 3.4.3 to 3.4.4
- add a 3.4.4 changelog entry for the interrupted text block fix
- keep package.json and package-lock.json in sync

## Testing
- not run (release metadata change only)