### PR TITLE
fix: fail canary with a named error on collapsed SDKMessage types (v3.5.1)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,8 +3,13 @@ name: SDK Canary
 # Weekly canary against @anthropic-ai/claude-agent-sdk@latest.
 #
 # A failure here means UPSTREAM SDK DRIFT (a new @latest broke typecheck or
-# tests, including the compile-time Options drift guard in
-# src/options-coverage.test.ts) — NOT a regression in this repository.
+# tests) — NOT a regression in this repository. Typecheck includes guards in
+# src/options-coverage.test.ts:
+#   - Options drift: a new/changed Options key; map it or add it to
+#     KnownExcludedKey.
+#   - SDKMessage_collapsed_to_any: broken upstream d.ts references missing
+#     union members; report/track upstream and wait for a fixed release before
+#     bumping.
 # The pinned-dependency CI workflow (ci.yml) is the repo-health signal.
 
 on:
@@ -95,14 +100,17 @@ jobs:
               `- Failed step: ${failedStep}`,
               `- Pinned range: \`${JSON.parse(fs.readFileSync('package.json', 'utf8')).dependencies['@anthropic-ai/claude-agent-sdk']}\``,
               '',
-              'A failure here means **upstream SDK drift** — typecheck (including the Options',
-              'drift guard in `src/options-coverage.test.ts`, which names any new `Options` key)',
-              'or unit tests broke against `@latest` — not a regression in this repository.',
+              'A failure here means **upstream SDK drift** — typecheck (including guards in',
+              '`src/options-coverage.test.ts`) or unit tests broke against `@latest`, not a',
+              'regression in this repository.',
               '',
-              'Triage: check the failed step in the run log. A typecheck failure usually means',
-              'a new or changed SDK type (map it or add it to `KnownExcludedKey`); a test',
-              'failure means runtime behavior changed and needs investigation before the next',
-              'dependency bump.',
+              'Triage: check the failed step in the run log. For Options drift guard errors,',
+              'the SDK added/changed an `Options` key; map it or add it to `KnownExcludedKey`.',
+              'If a typecheck error names `SDKMessage_collapsed_to_any`, upstream published',
+              'a broken d.ts (the `SDKMessage` union references undeclared members); there is',
+              'nothing to fix repo-side — report/track upstream and wait for a fixed release',
+              'before bumping. A test failure means runtime behavior changed and needs',
+              'investigation before the next dependency bump.',
             ].join('\n');
             // Paginate so the tracking issue is still found (and not duplicated)
             // even if the repo ever has more than 100 open issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1] - 2026-07-06
+
+### Fixed
+
+- **Weekly SDK canary triage for `SDKMessage` collapse** - The canary against `@anthropic-ai/claude-agent-sdk@0.3.201` failed with two misleading TS7006 errors because that release's published `sdk.d.ts` references `SDKControlRequestProgressMessage` and `SDKConversationResetMessage` in the `SDKMessage` union without declaring either type (upstream anthropics/claude-agent-sdk-typescript#363, unfixed as of 0.3.201). Under this repository's `skipLibCheck` setting, those missing names collapse the whole union to `any`, hiding the real upstream type breakage behind uncontextualized callbacks.
+- **Result-error filters hardened without runtime changes** - The two result-error filter callbacks are now explicitly annotated as `(e: unknown): e is string`, so collapsed contextual typing cannot surface as TS7006. The filter predicate and runtime behavior are unchanged.
+- **Self-documenting compile-time guard for broken SDK releases** - `src/options-coverage.test.ts` now fails typecheck with a single named error (`SDKMessage_collapsed_to_any__...`) whenever the `SDKMessage` union collapses, keeping the weekly canary red for the real reason and blocking a dependency bump onto a broken SDK release.
+- **Canary failure guidance split by failure mode** - Canary workflow comments and the auto-filed issue text now give separate triage guidance for Options drift versus SDKMessage collapse. The pinned dependency is unchanged (`^0.3.170`, with lockfile `0.3.170`), and this release makes no runtime behavior changes.
+
 ## [3.5.0] - 2026-06-10
 
 This release upgrades the provider to `@anthropic-ai/claude-agent-sdk` 0.3.x (from 0.2.63) and closes the resulting capability gap in one pass: every non-excluded SDK `Options` field is now reachable as a first-class setting (enforced by a new compile-time drift guard), stream handling understands the new 0.3.x message types (refusal fallbacks, superseded messages, timing metadata), AI SDK conformance is tightened (honest warnings, tool-call history round-trip, an MCP bridge helper for AI SDK tools, and `doGenerate` now surfaces provider-executed tool parts in `content`), and session lifecycle helpers, warm-start re-exports, and user-dialog support are exposed. A weekly canary CI job now tests against `@anthropic-ai/claude-agent-sdk@latest` to catch upstream drift early.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -31,7 +31,7 @@ import type {
  * Provider version reported to the Agent SDK via CLAUDE_AGENT_SDK_CLIENT_APP.
  * Keep in sync with package.json (kept as a constant to avoid a build step).
  */
-const PROVIDER_VERSION = '3.5.0';
+const PROVIDER_VERSION = '3.5.1';
 const DEFAULT_CLIENT_APP = `ai-sdk-provider-claude-code/${PROVIDER_VERSION}`;
 
 const CLAUDE_CODE_TRUNCATION_WARNING =

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -2669,7 +2669,9 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                 : undefined;
             const errorsText =
               'errors' in message && Array.isArray(message.errors)
-                ? message.errors.filter((e): e is string => typeof e === 'string').join('; ')
+                ? message.errors
+                    .filter((e: unknown): e is string => typeof e === 'string')
+                    .join('; ')
                 : '';
             const errorMessage = resultText ?? (errorsText || 'Claude Code CLI returned an error');
             throw Object.assign(new Error(errorMessage), {
@@ -4001,7 +4003,9 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                     : undefined;
                 const errorsText =
                   'errors' in message && Array.isArray(message.errors)
-                    ? message.errors.filter((e): e is string => typeof e === 'string').join('; ')
+                    ? message.errors
+                        .filter((e: unknown): e is string => typeof e === 'string')
+                        .join('; ')
                     : '';
                 const errorMessage =
                   resultText ?? (errorsText || 'Claude Code CLI returned an error');

--- a/src/options-coverage.test.ts
+++ b/src/options-coverage.test.ts
@@ -24,7 +24,7 @@
  * `MappedKey`), or adding it to `KnownExcludedKey` with a reason.
  */
 import { describe, expect, it } from 'vitest';
-import type { Options } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 /**
  * Every `Options` field that `createQueryOptions` in
@@ -132,6 +132,21 @@ type UnaccountedSdkOptionKey = Exclude<keyof Options, AccountedKey>;
  */
 type StaleAccountedKey = Exclude<AccountedKey, keyof Options>;
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type HasAnyKeyspace<T> = string extends keyof T ? true : false;
+
+/**
+ * Broken published SDK declarations can reference missing union members. With
+ * skipLibCheck, those missing names collapse `SDKMessage` to `any`; canary must
+ * fail loudly/actionably here instead of leaking stray TS7006s elsewhere.
+ */
+type CollapsedSdkMessageAnyKey =
+  HasAnyKeyspace<SDKMessage> extends true
+    ? 'SDKMessage_collapsed_to_any__fix_upstream_claude_agent_sdk_dts_missing_union_members'
+    : IsAny<SDKMessage> extends true
+      ? 'SDKMessage_collapsed_to_any__fix_upstream_claude_agent_sdk_dts_missing_union_members'
+      : never;
+
 // Compile-time guards. `Record<never, never>` is `{}`, so these only compile
 // while the corresponding union is empty; otherwise tsc names the missing
 // key(s), e.g.:
@@ -147,6 +162,7 @@ const providerManagedKeysOverlappingExcluded: Record<
   Extract<ProviderManagedKey, KnownExcludedKey>,
   never
 > = {};
+const sdkMessageMustNotCollapseToAny: Record<CollapsedSdkMessageAnyKey, never> = {};
 
 describe('SDK Options drift guard', () => {
   it('accounts for every key of the SDK Options type', () => {
@@ -161,5 +177,9 @@ describe('SDK Options drift guard', () => {
   it('keeps the three buckets disjoint', () => {
     expect(Object.keys(mappedKeysOverlappingOtherBuckets)).toEqual([]);
     expect(Object.keys(providerManagedKeysOverlappingExcluded)).toEqual([]);
+  });
+
+  it('keeps SDKMessage from collapsing to any', () => {
+    expect(Object.keys(sdkMessageMustNotCollapseToAny)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

The weekly SDK canary (run 28775194645, tracked in #130) failed against `@anthropic-ai/claude-agent-sdk@0.3.201` with two misleading errors:

```
src/claude-code-language-model.ts(2672,42): error TS7006: Parameter 'e' implicitly has an 'any' type.
src/claude-code-language-model.ts(4004,46): error TS7006: Parameter 'e' implicitly has an 'any' type.
```

**Root cause is upstream:** 0.3.201's published `sdk.d.ts` (line 3772) references `SDKControlRequestProgressMessage` and `SDKConversationResetMessage` in the `SDKMessage` union without declaring either type anywhere in the package. Under `skipLibCheck: true` the unresolved names become the error type, and `T | any = any` collapses the **entire `SDKMessage` union to `any`** — silently disabling all discriminated-union checking. The only visible symptoms were the two unannotated type-predicate callbacks. Reported upstream: anthropics/claude-agent-sdk-typescript#363 (open, filed against 0.3.198; still broken in 0.3.201 — `latest` and `next` both resolve to 0.3.201, no fixed release exists).

## Changes

- **Harden the two filter callbacks** — `(e: unknown): e is string`; compiles identically against 0.3.170 and 0.3.201, zero runtime change.
- **Add a compile-time collapse guard** (`src/options-coverage.test.ts`, same idiom as the Options drift guard) — typecheck fails with one self-documenting error (`SDKMessage_collapsed_to_any__fix_upstream_claude_agent_sdk_dts_missing_union_members`) whenever `SDKMessage` degrades to `any`. The canary stays **red on purpose** against broken releases (a vacuously-green typecheck over an all-`any` union would hide real drift), and a dependency bump onto a broken SDK version cannot go green.
- **Update canary triage text** (`canary.yml` header comment + auto-filed issue body; comments/strings only, no workflow logic) — separate guidance for Options drift (map/exclude the key) vs `SDKMessage` collapse (broken upstream d.ts; nothing to fix repo-side).
- **Version 3.5.1 + CHANGELOG entry.** Pinned dependency unchanged (`^0.3.170`, lockfile 0.3.170); no runtime behavior changes.

## Verification

Against pinned 0.3.170 (fresh `npm ci --legacy-peer-deps`):
- `npm run format:check` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (782/782, 28 files)

Against 0.3.201 overlay (`npm install --no-save --ignore-scripts --legacy-peer-deps @anthropic-ai/claude-agent-sdk@latest`):
- `npm run typecheck` ❌ **exactly one error — the named guard; zero TS7006** (intended: canary stays red with an actionable reason until upstream ships fixed declarations)
- `npm run test` ✅ (782/782 — the 0.3.201 breakage is declarations-only)

## Notes

- Refs #130 (deliberately not `Fixes` — the canary will keep failing, now with a self-explanatory error, until upstream resolves anthropics/claude-agent-sdk-typescript#363; #130 stays open as the tracking issue).
- When a fixed SDK release ships, the guard compiles clean and the canary goes green with no further changes here; that is the right moment to bump the lockfile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time and documentation-only changes plus explicit callback types; no runtime or dependency pin changes.
> 
> **Overview**
> **v3.5.1** hardens typecheck and weekly canary behavior when upstream `@anthropic-ai/claude-agent-sdk` ships broken `sdk.d.ts` that collapses the `SDKMessage` union to `any` (misleading TS7006s elsewhere instead of a clear drift signal).
> 
> A compile-time guard in `src/options-coverage.test.ts` fails typecheck with a single named error (`SDKMessage_collapsed_to_any__...`) when `SDKMessage` degrades, matching the existing Options drift pattern. The two result-error `errors` filters in `claude-code-language-model.ts` now use `(e: unknown): e is string` so they still typecheck if contextual typing breaks; runtime behavior is unchanged.
> 
> Canary workflow comments and auto-filed issue bodies split triage: Options drift (map or `KnownExcludedKey`) vs `SDKMessage` collapse (upstream d.ts; wait for a fixed release before bumping). Version bumps to **3.5.1**; pinned SDK stays `^0.3.170`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc95352cfd42faa6a2ffd06e93e8e24e13d66de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->