### PR TITLE
ci: add ai-sdk-v5 branch-local CI trigger and default publish tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [ai-sdk-v5]
   pull_request:
-    branches: [main, develop]
+    branches: [ai-sdk-v5]
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "ai-sdk-v5"
   }
 }


### PR DESCRIPTION
Backfills Phase 0 maintenance-branch guards from the AI SDK v7 upgrade plan: branch-local CI trigger for ai-sdk-v5 and publishConfig.tag=ai-sdk-v5 so accidental npm publish cannot land on latest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and publish metadata only; no application runtime or security logic changes.
> 
> **Overview**
> **CI** now runs only for the `ai-sdk-v5` branch (push and pull_request), replacing triggers on `main` and `develop` so this maintenance line has its own pipeline.
> 
> **Publishing** adds `publishConfig.tag: "ai-sdk-v5"` so `npm publish` defaults to the `ai-sdk-v5` dist-tag instead of `latest`, reducing the chance of shipping this branch’s builds to the default tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e6d128d08073ab82b4272b068fe608d700e72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->