### PR TITLE
ci: add v1 branch-local CI trigger and v1-claude-code-sdk publish tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [v1]
   pull_request:
-    branches: [main, develop]
+    branches: [v1]
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "node": ">=20"
     },
     "publishConfig": {
-        "access": "public"
+        "access": "public",
+        "tag": "v1-claude-code-sdk"
     }
 }


### PR DESCRIPTION
Backfills Phase 0 maintenance-branch guards from the AI SDK v7 upgrade plan: branch-local CI trigger for v1 and publishConfig.tag=v1-claude-code-sdk so accidental npm publish cannot land on latest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and publish metadata only; no runtime, auth, or application logic changes.
> 
> **Overview**
> **CI** now runs only for pushes and pull requests targeting the **`v1`** branch, replacing **`main`** and **`develop`** as trigger branches.
> 
> **npm** **`publishConfig`** adds **`tag: v1-claude-code-sdk`** so publishes from this maintenance line default to that dist-tag instead of **`latest`**, reducing the risk of accidental releases on the default tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e964c0d9d1b1a6d09243ca9f282a367c9b9fd09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->