### PR TITLE
chore: raise @anthropic-ai/claude-agent-sdk floor to ^0.3.205 (3.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.2] - 2026-07-10
+
+### Changed
+
+- **`@anthropic-ai/claude-agent-sdk` floor raised to `^0.3.205`** - The previous range (`^0.3.170`) still admitted the `0.3.198`–`0.3.202` releases whose published `sdk.d.ts` referenced undeclared `SDKMessage` union members (upstream anthropics/claude-agent-sdk-typescript#363, fixed in `0.3.203`), so a constrained resolver or stale lockfile could settle on a broken-types SDK while satisfying the declared range. The new floor excludes that window. Fresh installs already resolved above it; compatibility with current `@latest` (`0.3.206`) is verified by the SDK canary on this branch. No runtime behavior changes.
+
 ## [3.5.1] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ A few Agent SDK surfaces are deliberately not wrapped by this provider. A compil
 
 ## Claude Agent SDK 0.3.x Notes
 
-This provider depends on `@anthropic-ai/claude-agent-sdk@^0.3.170`. The 0.3.x line introduces a few changes worth knowing about:
+This provider depends on `@anthropic-ai/claude-agent-sdk@^0.3.205`. The 0.3.x line introduces a few changes worth knowing about:
 
 ### New peer dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "@ai-sdk/provider-utils": "^4.0.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.170"
+        "@anthropic-ai/claude-agent-sdk": "^0.3.205"
       },
       "devDependencies": {
         "@edge-runtime/vm": "5.0.0",
@@ -98,22 +98,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.170.tgz",
-      "integrity": "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.206.tgz",
+      "integrity": "sha512-KljDh9Pg4YCYpoXS8dnWoVSsOHtU4yLCW268K2iOruSxFXE8/Tay6DPvmJzYuqjP5YLNYfj05ZGykwZSUn6GXA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.206"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.170.tgz",
-      "integrity": "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.206.tgz",
+      "integrity": "sha512-FL2+NKcMMN47vcnCW2Fkt3AOgeRRlQxrisbPNaxrxqPJFzhUKs17x5j0XzLefd0xRbDAr74hd0PK/tnp6PHM6w==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.170.tgz",
-      "integrity": "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.206.tgz",
+      "integrity": "sha512-mRW8PPMfQN15EunLwpdmcVzk3XuM4DXQUM8DOzaeA1Hr1yxYPaVVBLr9hkdBKOqr8XTl3ueoTR6RZAy6a/n7OA==",
       "cpu": [
         "x64"
       ],
@@ -148,9 +148,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.170.tgz",
-      "integrity": "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.206.tgz",
+      "integrity": "sha512-Id6H8l6EsGb7849EAZDOB4Ic+FQpbzt4D5HGOwp59CTW3o/1c4etjQA/Kl1K+DSEWn3FGo6D5UMVgc/rwhBj8g==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.170.tgz",
-      "integrity": "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.206.tgz",
+      "integrity": "sha512-aMZe1Kl+kYv5QlA15W9Ae25MAzBsA9FA40f5TOtJebA+M/xliF0r2LLb2NdyBviiZCDllcE31l0zgYE0rQqFQw==",
       "cpu": [
         "arm64"
       ],
@@ -174,9 +174,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.170.tgz",
-      "integrity": "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.206.tgz",
+      "integrity": "sha512-egZhOC1RlEVhZyq6Oa1b04AF7hh4hO+8oCsJCZ3gOifJQuHih1oW3lZ8fOUxU85jlT2ytAnt5kRp4uQr6PJgbg==",
       "cpu": [
         "x64"
       ],
@@ -187,9 +187,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.170.tgz",
-      "integrity": "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.206.tgz",
+      "integrity": "sha512-xQBOBhlcmTNc7YeYT5qLZOikpSq3WHlsJ/t6i7kJqUWrcXlOPaAoSMdKp5xO/V0CjAdzdJoWB88I55UAh8mclQ==",
       "cpu": [
         "x64"
       ],
@@ -200,9 +200,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.170.tgz",
-      "integrity": "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.206.tgz",
+      "integrity": "sha512-oRQk23bFXSz4QRhOxqnnvlLWq/KiF2PtSBYXrMg1AQrCOHJd2k66aOAS7AJ4ZSzejiyV4N6sS6UThfmF6ipHBQ==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +213,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.170.tgz",
-      "integrity": "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.206.tgz",
+      "integrity": "sha512-BdjKmDojZjc5RjN+8Q6K7Yqf1WYhel6I3DkMXc9zdxS/xIuN42sx7zgQpdMGY73pm7ROPLqo3LieOeMhVH161w==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",
@@ -81,7 +81,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^3.0.0",
     "@ai-sdk/provider-utils": "^4.0.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.170"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.205"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -31,7 +31,7 @@ import type {
  * Provider version reported to the Agent SDK via CLAUDE_AGENT_SDK_CLIENT_APP.
  * Keep in sync with package.json (kept as a constant to avoid a build step).
  */
-const PROVIDER_VERSION = '3.5.1';
+const PROVIDER_VERSION = '3.5.2';
 const DEFAULT_CLIENT_APP = `ai-sdk-provider-claude-code/${PROVIDER_VERSION}`;
 
 const CLAUDE_CODE_TRUNCATION_WARNING =


### PR DESCRIPTION
## Summary

Raises the 3.x maintenance line's `@anthropic-ai/claude-agent-sdk` range from `^0.3.170` to `^0.3.205` and bumps the provider to `3.5.2`.

The old range still admitted the `0.3.198`–`0.3.202` releases whose published `sdk.d.ts` referenced undeclared `SDKMessage` union members (upstream anthropics/claude-agent-sdk-typescript#363, fixed in `0.3.203`), so a constrained resolver or stale lockfile could settle on a broken-types SDK while satisfying the declared range. The new floor excludes that window. Fresh installs already resolved above it, so this changes the contract, not what new users get.

## Changes

- `package.json`: dependency floor `^0.3.170` → `^0.3.205`; version `3.5.1` → `3.5.2`
- `package-lock.json`: regenerated (resolves `0.3.206`)
- `src/claude-code-language-model.ts`: `PROVIDER_VERSION` User-Agent constant → `3.5.2`
- `CHANGELOG.md`: 3.5.2 entry

No runtime behavior changes.

## Verification

- 782/782 tests pass locally against `0.3.206`; lint, typecheck, build, and format:check clean
- Branch canary vs `@latest` (`0.3.206`) passed earlier today: https://github.com/ben-vargas/ai-sdk-provider-claude-code/actions/runs/29106814739

Related: #130