### PR TITLE
fix: surface captured stderr in error messages and classification (v6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3] - 2026-07-10
+
+### Fixed
+
+- **Visible and bounded subprocess diagnostics** ([#136](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/136)) - Error messages now carry a trimmed stderr tail, authentication and timeout classification also inspect captured stderr using separate high-precision login/API-key and timeout phrases to avoid incidental matches, and retained stderr stored in mapped error metadata is capped at 4000 characters.
+
 ## [3.5.2] - 2026-07-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Visible and bounded subprocess diagnostics** ([#136](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/136)) - Error messages now carry a trimmed stderr tail, authentication and timeout classification also inspect captured stderr using separate high-precision login/API-key and timeout phrases to avoid incidental matches, and retained stderr stored in mapped error metadata is capped at 4000 characters.
+- **Visible and bounded subprocess diagnostics** ([#136](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/136)) - Error messages now carry a trimmed stderr tail, authentication and timeout classification also inspect captured stderr using separate high-precision login/API-key and timeout phrases to avoid incidental matches, and retained stderr stored in mapped error metadata, including timeout errors, is capped at 4000 characters.
 
 ## [3.5.2] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -616,6 +616,22 @@ All requests made through this provider report timing in `providerMetadata['clau
 - When replaying conversation history through the prompt, assistant tool calls are serialized as text lines — `[Tool call: Read({"file_path":"/x"})]` (inputs truncated at 1000 characters) — paired with `Tool Result (Read): ...` lines for tool messages
 - `canUseTool` requires streaming input at the SDK level (AsyncIterable prompt). This provider supports it via `streamingInput`: use `'auto'` (default when `canUseTool` is set) or `'always'`. See GUIDE for details.
 
+## Error Diagnostics
+
+Mapped provider errors append a trimmed stderr tail directly to the message as `... | stderr (tail): <last lines>`, making failures visible in logs without inspecting metadata. The full captured stderr (capped at 4000 characters) remains available through `getErrorMetadata`:
+
+```typescript
+import { generateText } from 'ai';
+import { claudeCode, getErrorMetadata } from 'ai-sdk-provider-claude-code';
+try {
+  await generateText({ model: claudeCode('haiku'), prompt: 'Hello, Claude!' });
+} catch (error) {
+  console.error(getErrorMetadata(error)?.stderr);
+}
+```
+
+Authentication and timeout failures are also classified when the only evidence is in stderr, using high-precision matching to avoid false positives from unrelated stderr output.
+
 ## Tool Error Parity (Streaming)
 
 - In addition to `tool-call` and `tool-result`, this provider emits a distinct `tool-error` stream event when a tool execution fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-claude-code",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-claude-code",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "AI SDK v6 provider for Claude via Claude Agent SDK (use Pro/Max subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1869,6 +1869,26 @@ describe('ClaudeCodeLanguageModel', () => {
       expect((thrownError as Error).message).toContain('Please run: claude login');
     });
 
+    it('classifies a bare SDK exit error as auth from not authenticated stderr', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('Error: Not authenticated');
+        throw new Error('Claude Code process exited with code 1');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(LoadAPIKeyError);
+      expect(isAuthenticationError(thrownError)).toBe(true);
+      expect((thrownError as Error).message).toContain('stderr (tail): Error: Not authenticated');
+    });
+
     it('does not classify incidental auth wording on stderr as an auth error', async () => {
       vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
         options?.stderr?.(

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
 import { getErrorMetadata, isAuthenticationError } from './errors.js';
 import type { Logger } from './types.js';
-import { APICallError, type LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import { APICallError, LoadAPIKeyError, type LanguageModelV3StreamPart } from '@ai-sdk/provider';
 
 // Extend stream part union locally to include provider-specific 'tool-error'
 type ToolErrorPart = {
@@ -1606,8 +1606,8 @@ describe('ClaudeCodeLanguageModel', () => {
 
       vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
         if (options?.stderr) {
-          options.stderr('Error: Not authenticated\n');
-          options.stderr('Please run: claude login\n');
+          options.stderr('Diagnostic chunk one\n');
+          options.stderr('Diagnostic chunk two\n');
         }
         const error = new Error('Failed with exit code: 1');
         (error as any).exitCode = 1;
@@ -1623,10 +1623,10 @@ describe('ClaudeCodeLanguageModel', () => {
         thrownError = error;
       }
 
-      expect(sdkStderr).toHaveBeenCalledWith('Error: Not authenticated\n');
-      expect(sdkStderr).toHaveBeenCalledWith('Please run: claude login\n');
+      expect(sdkStderr).toHaveBeenCalledWith('Diagnostic chunk one\n');
+      expect(sdkStderr).toHaveBeenCalledWith('Diagnostic chunk two\n');
       const metadata = getErrorMetadata(thrownError);
-      expect(metadata?.stderr).toBe('Error: Not authenticated\nPlease run: claude login\n');
+      expect(metadata?.stderr).toBe('Diagnostic chunk one\nDiagnostic chunk two\n');
       expect(metadata?.exitCode).toBe(1);
     });
     it('should generate text from SDK response', async () => {
@@ -1827,7 +1827,7 @@ describe('ClaudeCodeLanguageModel', () => {
       await expect(promise).rejects.toThrow(abortReason);
     });
 
-    it('should capture stderr from callback when SDK throws error', async () => {
+    it('should classify a bare SDK exit error as auth from captured stderr', async () => {
       const stderrMessages: string[] = [];
       const stderrCallback = vi.fn((data: string) => {
         stderrMessages.push(data);
@@ -1846,10 +1846,8 @@ describe('ClaudeCodeLanguageModel', () => {
           options.stderr('Please run: claude login\n');
         }
 
-        // Throw an error with exitCode (like auth failure)
-        const error = new Error('Failed with exit code: 1');
-        (error as any).exitCode = 1;
-        throw error;
+        // The pinned SDK throws a bare process-exit error without stderr or exitCode.
+        throw new Error('Claude Code process exited with code 1');
       });
 
       let thrownError: unknown;
@@ -1865,12 +1863,155 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(stderrCallback).toHaveBeenCalledWith('Error: Not authenticated\n');
       expect(stderrCallback).toHaveBeenCalledWith('Please run: claude login\n');
 
-      // Verify the error contains the stderr data
       expect(thrownError).toBeDefined();
-      const metadata = getErrorMetadata(thrownError);
-      expect(metadata).toBeDefined();
-      expect(metadata?.stderr).toBe('Error: Not authenticated\nPlease run: claude login\n');
-      expect(metadata?.exitCode).toBe(1);
+      expect(thrownError).toBeInstanceOf(LoadAPIKeyError);
+      expect(isAuthenticationError(thrownError)).toBe(true);
+      expect((thrownError as Error).message).toContain('Please run: claude login');
+    });
+
+    it('does not classify incidental auth wording on stderr as an auth error', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.(
+          'fetch failed: 401 Unauthorized from https://internal.example\n' +
+            '[debug] authentication middleware initialized\n'
+        );
+        throw new Error('Claude Code process exited with code 1');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect(thrownError).not.toBeInstanceOf(LoadAPIKeyError);
+      expect(isAuthenticationError(thrownError)).toBe(false);
+      expect((thrownError as Error).message).toContain(
+        'stderr (tail): fetch failed: 401 Unauthorized from https://internal.example'
+      );
+      expect((thrownError as Error).message).toContain(
+        '[debug] authentication middleware initialized'
+      );
+    });
+
+    it('surfaces and caps captured stderr for a bare SDK process-exit error', async () => {
+      const collectedStderr = `discarded-prefix-${'x'.repeat(4100)}\nkept diagnostic`;
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.(collectedStderr);
+        throw new Error('Claude Code process exited with code 1');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect((thrownError as Error).message).toContain('stderr (tail):');
+      expect((thrownError as Error).message).toContain('kept diagnostic');
+      const stderr = getErrorMetadata(thrownError)?.stderr;
+      expect(stderr).toBeDefined();
+      expect(Array.from(stderr ?? '')).toHaveLength(4000);
+      expect(stderr?.endsWith('kept diagnostic')).toBe(true);
+      expect(stderr).not.toContain('discarded-prefix');
+    });
+
+    it('classifies a bare SDK process-exit error as timeout from narrow stderr text', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('Request timed out while contacting the API\n');
+        throw new Error('Claude Code process exited with code 1');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect((thrownError as APICallError).isRetryable).toBe(true);
+      expect(getErrorMetadata(thrownError)?.code).toBe('TIMEOUT');
+      expect((thrownError as Error).message).toContain(
+        'stderr (tail): Request timed out while contacting the API'
+      );
+    });
+
+    it('does not classify incidental timeout wording on stderr as a timeout', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('Loaded timeout configuration from disk\n');
+        throw new Error('Claude Code process exited with code 1');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect((thrownError as APICallError).isRetryable).toBe(false);
+      expect(getErrorMetadata(thrownError)?.code).toBeUndefined();
+      expect((thrownError as Error).message).toContain('Loaded timeout configuration from disk');
+    });
+
+    it('prefers meaningful SDK error stderr and caps it before mapping', async () => {
+      const sdkStderr = `discarded-sdk-prefix-${'s'.repeat(4100)}\nSDK diagnostic`;
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('collected diagnostic\n');
+        const error = new Error('Claude Code process exited with code 1');
+        (error as Error & { stderr: string }).stderr = sdkStderr;
+        throw error;
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      const stderr = getErrorMetadata(thrownError)?.stderr;
+      expect(Array.from(stderr ?? '')).toHaveLength(4000);
+      expect(stderr?.endsWith('SDK diagnostic')).toBe(true);
+      expect(stderr).not.toContain('collected diagnostic');
+      expect(stderr).not.toContain('discarded-sdk-prefix');
+    });
+
+    it('falls back to collected stderr when SDK error stderr has no real content', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('collected diagnostic\n');
+        const error = new Error('Claude Code process exited with code 1');
+        (error as Error & { stderr: string }).stderr = ' \t\x1b[31m\x1b[0m ';
+        throw error;
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(getErrorMetadata(thrownError)?.stderr).toBe('collected diagnostic\n');
+      expect((thrownError as Error).message).toContain('collected diagnostic');
     });
 
     it('should detect /login pattern as authentication error', async () => {
@@ -2192,7 +2333,9 @@ describe('ClaudeCodeLanguageModel', () => {
 
       // Verify error was thrown
       expect(thrownError).toBeDefined();
-      expect((thrownError as Error).message).toBe('Some error occurred');
+      expect((thrownError as Error).message).toBe(
+        'Some error occurred | stderr (tail): Warning: some diagnostic info'
+      );
 
       // Verify error metadata includes collected stderr
       const metadata = getErrorMetadata(thrownError);
@@ -3437,6 +3580,40 @@ describe('ClaudeCodeLanguageModel', () => {
       expect((chunks[1] as any).error.message).toContain('Invalid API key');
       // The error should be converted to an auth error (contains /login pattern)
       expect(isAuthenticationError((chunks[1] as any).error)).toBe(true);
+    });
+
+    it('caps the streaming stderr collector before emitting an error', async () => {
+      const collectedStderr = `discarded-stream-prefix-${'y'.repeat(4100)}\nstream diagnostic`;
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield* [];
+            options?.stderr?.(collectedStderr);
+            throw new Error('Claude Code process exited with code 1');
+          },
+        } as any;
+      });
+
+      const result = await model.doStream({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+      });
+      const chunks: ExtendedStreamPart[] = [];
+      const reader = result.stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      const errorChunk = chunks.find((chunk) => chunk.type === 'error') as
+        | { type: 'error'; error: unknown }
+        | undefined;
+      expect(errorChunk?.error).toBeInstanceOf(APICallError);
+      const stderr = getErrorMetadata(errorChunk?.error)?.stderr;
+      expect(Array.from(stderr ?? '')).toHaveLength(4000);
+      expect(stderr?.endsWith('stream diagnostic')).toBe(true);
+      expect(stderr).not.toContain('discarded-stream-prefix');
+      expect((errorChunk?.error as Error).message).toContain('stream diagnostic');
     });
 
     it('should use stop_reason from result message for stream finish reason', async () => {

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1866,6 +1866,9 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(thrownError).toBeDefined();
       expect(thrownError).toBeInstanceOf(LoadAPIKeyError);
       expect(isAuthenticationError(thrownError)).toBe(true);
+      expect(getErrorMetadata(thrownError)?.stderr).toBe(
+        'Error: Not authenticated\nPlease run: claude login\n'
+      );
       expect((thrownError as Error).message).toContain('Please run: claude login');
     });
 
@@ -1886,6 +1889,7 @@ describe('ClaudeCodeLanguageModel', () => {
 
       expect(thrownError).toBeInstanceOf(LoadAPIKeyError);
       expect(isAuthenticationError(thrownError)).toBe(true);
+      expect(getErrorMetadata(thrownError)?.stderr).toBe('Error: Not authenticated');
       expect((thrownError as Error).message).toContain('stderr (tail): Error: Not authenticated');
     });
 

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1962,9 +1962,40 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(thrownError).toBeInstanceOf(APICallError);
       expect((thrownError as APICallError).isRetryable).toBe(true);
       expect(getErrorMetadata(thrownError)?.code).toBe('TIMEOUT');
+      expect(getErrorMetadata(thrownError)?.stderr).toBe(
+        'Request timed out while contacting the API\n'
+      );
       expect((thrownError as Error).message).toContain(
         'stderr (tail): Request timed out while contacting the API'
       );
+    });
+
+    it('classifies timeout from the capped SDK error stderr tail before mapping', async () => {
+      const sdkStderr = `discarded-sdk-prefix-${'s'.repeat(4100)}\nRequest timed out from SDK stderr`;
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('collected diagnostic\n');
+        const error = new Error('Claude Code process exited with code 1');
+        (error as Error & { stderr: string }).stderr = sdkStderr;
+        throw error;
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(getErrorMetadata(thrownError)?.code).toBe('TIMEOUT');
+      expect((thrownError as APICallError).isRetryable).toBe(true);
+      const stderr = getErrorMetadata(thrownError)?.stderr;
+      expect(Array.from(stderr ?? '').length).toBeLessThanOrEqual(4000);
+      expect(stderr?.endsWith('Request timed out from SDK stderr')).toBe(true);
+      expect(stderr).not.toContain('discarded-sdk-prefix');
+      expect((thrownError as Error).message).toContain('stderr (tail):');
+      expect((thrownError as Error).message).toContain('Request timed out from SDK stderr');
     });
 
     it('does not classify incidental timeout wording on stderr as a timeout', async () => {

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1907,6 +1907,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     // cannot misclassify an unrelated CLI process failure as an auth failure.
     const stderrAuthPatterns = [
       'not logged in',
+      'not authenticated',
       'auth failed',
       'please login',
       'please run /login',

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1857,16 +1857,21 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
       return error;
     }
 
-    const stderrFromError =
+    const rawSdkStderr =
       typeof error === 'object' &&
       error !== null &&
       'stderr' in error &&
-      typeof error.stderr === 'string' &&
-      stderrTail(error.stderr)
+      typeof error.stderr === 'string'
         ? error.stderr
         : undefined;
-    const selectedStderr = stderrFromError ?? collectedStderr;
-    const stderr = selectedStderr ? capStderr(selectedStderr) : undefined;
+    const cappedSdkStderr = rawSdkStderr !== undefined ? capStderr(rawSdkStderr) : undefined;
+    const selectedStderr =
+      cappedSdkStderr !== undefined && stderrTail(cappedSdkStderr)
+        ? cappedSdkStderr
+        : collectedStderr
+          ? capStderr(collectedStderr)
+          : undefined;
+    const stderr = selectedStderr || undefined;
     const tail = stderr ? stderrTail(stderr) : '';
     const appendStderrTail = (message: string): string =>
       tail && !message.includes(STDERR_TAIL_MARKER)
@@ -1958,6 +1963,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
         message: appendStderrTail(
           isErrorWithMessage(error) && error.message ? error.message : 'Request timed out'
         ),
+        stderr,
         promptExcerpt: messagesPrompt.substring(0, 200),
         // Don't specify timeoutMs since we don't know the actual timeout value
         // It's controlled by the consumer via AbortSignal

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1948,6 +1948,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
             ? error.message
             : 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.'
         ),
+        stderr,
       });
     }
 

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -14,7 +14,13 @@ import { NoSuchModelError, APICallError, LoadAPIKeyError } from '@ai-sdk/provide
 import { generateId } from '@ai-sdk/provider-utils';
 import type { ClaudeCodeSettings, Logger, MessageInjector } from './types.js';
 import { convertToClaudeCodeMessages } from './convert-to-claude-code-messages.js';
-import { createAPICallError, createAuthenticationError, createTimeoutError } from './errors.js';
+import {
+  createAPICallError,
+  createAuthenticationError,
+  createTimeoutError,
+  STDERR_TAIL_MARKER,
+  stderrTail,
+} from './errors.js';
 import { mapClaudeCodeFinishReason } from './map-claude-code-finish-reason.js';
 import { validateModelId, validatePrompt, validateSessionId, isBlankResume } from './validation.js';
 import { sanitizeJsonSchemaForOutputFormat } from './sanitize-json-schema.js';
@@ -31,13 +37,21 @@ import type {
  * Provider version reported to the Agent SDK via CLAUDE_AGENT_SDK_CLIENT_APP.
  * Keep in sync with package.json (kept as a constant to avoid a build step).
  */
-const PROVIDER_VERSION = '3.5.2';
+const PROVIDER_VERSION = '3.5.3';
 const DEFAULT_CLIENT_APP = `ai-sdk-provider-claude-code/${PROVIDER_VERSION}`;
 
 const CLAUDE_CODE_TRUNCATION_WARNING =
   'Claude Code SDK output ended unexpectedly; returning truncated response from buffered text. Await upstream fix to avoid data loss.';
 
 const MIN_TRUNCATION_LENGTH = 512;
+
+function capStderr(raw: string): string {
+  if (raw.length <= 4000) {
+    return raw;
+  }
+
+  return Array.from(raw).slice(-4000).join('');
+}
 
 /**
  * Detects if an error represents a truncated SDK JSON stream.
@@ -1836,17 +1850,33 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     messagesPrompt: string,
     collectedStderr?: string
   ): APICallError | LoadAPIKeyError {
-    // Handle AbortError from the SDK
-    if (isAbortError(error)) {
-      // Return the abort reason if available, otherwise the error itself
-      throw error;
-    }
-
     // Already-classified provider errors (e.g. the missing-structured-output
     // failure thrown from result handling) pass through unchanged instead of
     // being re-wrapped with their metadata dropped.
     if (error instanceof APICallError || error instanceof LoadAPIKeyError) {
       return error;
+    }
+
+    const stderrFromError =
+      typeof error === 'object' &&
+      error !== null &&
+      'stderr' in error &&
+      typeof error.stderr === 'string' &&
+      stderrTail(error.stderr)
+        ? error.stderr
+        : undefined;
+    const selectedStderr = stderrFromError ?? collectedStderr;
+    const stderr = selectedStderr ? capStderr(selectedStderr) : undefined;
+    const tail = stderr ? stderrTail(stderr) : '';
+    const appendStderrTail = (message: string): string =>
+      tail && !message.includes(STDERR_TAIL_MARKER)
+        ? `${message}${STDERR_TAIL_MARKER} ${tail}`
+        : message;
+
+    // Handle AbortError from the SDK
+    if (isAbortError(error)) {
+      // Return the abort reason if available, otherwise the error itself
+      throw error;
     }
 
     // Type guard for error with properties
@@ -1873,9 +1903,23 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
       'invalid api key',
       'oauth_org_not_allowed', // SDK 0.3.x assistant error kind: OAuth org not permitted
     ];
+    // Keep stderr matching high-precision so incidental third-party/tool noise
+    // cannot misclassify an unrelated CLI process failure as an auth failure.
+    const stderrAuthPatterns = [
+      'not logged in',
+      'auth failed',
+      'please login',
+      'please run /login',
+      'claude login',
+      'claude auth login',
+      'invalid api key',
+      'oauth token revoked',
+      'oauth_org_not_allowed',
+    ];
 
     const errorMessage =
       isErrorWithMessage(error) && error.message ? error.message.toLowerCase() : '';
+    const stderrMessage = stderr?.toLowerCase() ?? '';
 
     // Structured kind (SDKAssistantMessageError) propagated from result handling;
     // preferred over substring matching since SDK error text need not contain it.
@@ -1888,33 +1932,36 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
       errorKind === 'authentication_failed' ||
       errorKind === 'oauth_org_not_allowed' ||
       authErrorPatterns.some((pattern) => errorMessage.includes(pattern)) ||
+      stderrAuthPatterns.some((pattern) => stderrMessage.includes(pattern)) ||
       exitCode === 401;
 
     if (isAuthError) {
       return createAuthenticationError({
-        message:
+        message: appendStderrTail(
           isErrorWithMessage(error) && error.message
             ? error.message
-            : 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.',
+            : 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.'
+        ),
       });
     }
 
     // Check for timeout errors
     const errorCode = isErrorWithCode(error) && typeof error.code === 'string' ? error.code : '';
 
-    if (errorCode === 'ETIMEDOUT' || errorMessage.includes('timeout')) {
+    if (
+      errorCode === 'ETIMEDOUT' ||
+      errorMessage.includes('timeout') ||
+      /request timed out|etimedout/i.test(stderr ?? '')
+    ) {
       return createTimeoutError({
-        message: isErrorWithMessage(error) && error.message ? error.message : 'Request timed out',
+        message: appendStderrTail(
+          isErrorWithMessage(error) && error.message ? error.message : 'Request timed out'
+        ),
         promptExcerpt: messagesPrompt.substring(0, 200),
         // Don't specify timeoutMs since we don't know the actual timeout value
         // It's controlled by the consumer via AbortSignal
       });
     }
-
-    // Use error.stderr if available from SDK, otherwise use collected stderr
-    const stderrFromError =
-      isErrorWithCode(error) && typeof error.stderr === 'string' ? error.stderr : undefined;
-    const stderr = stderrFromError || collectedStderr || undefined;
 
     // SDK 0.3.x assistant error kinds: API overload / rate limit — transient, safe to retry.
     if (
@@ -2219,6 +2266,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     let collectedStderr = '';
     const stderrCollector = (data: string) => {
       collectedStderr += data;
+      collectedStderr = capStderr(collectedStderr);
     };
 
     const sdkOptions = this.getSanitizedSdkOptions();
@@ -2913,6 +2961,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     let collectedStderr = '';
     const stderrCollector = (data: string) => {
       collectedStderr += data;
+      collectedStderr = capStderr(collectedStderr);
     };
 
     const sdkOptions = this.getSanitizedSdkOptions();

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -137,6 +137,18 @@ describe('Error Creation Functions', () => {
 
       expect(error).toBeInstanceOf(LoadAPIKeyError);
       expect(error.message).toBe('Auth failed');
+      expect(getErrorMetadata(error)).toBeUndefined();
+    });
+
+    it('should expose stderr metadata for authentication errors', () => {
+      const error = createAuthenticationError({
+        message: 'Auth failed',
+        stderr: 'Not authenticated',
+      });
+
+      expect(error).toBeInstanceOf(LoadAPIKeyError);
+      expect(isAuthenticationError(error)).toBe(true);
+      expect(getErrorMetadata(error)?.stderr).toBe('Not authenticated');
     });
 
     it('should use default message when empty', () => {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -6,8 +6,43 @@ import {
   isAuthenticationError,
   isTimeoutError,
   getErrorMetadata,
+  stderrTail,
 } from './errors.js';
 import { APICallError, LoadAPIKeyError } from '@ai-sdk/provider';
+
+describe('stderrTail', () => {
+  it('selects, orders, and trims the last five non-empty lines', () => {
+    expect(stderrTail(' first \n\nsecond\u2028 third \u2029fourth\nfifth\n sixth ')).toBe(
+      'second; third; fourth; fifth; sixth'
+    );
+  });
+
+  it('handles single-line input', () => {
+    expect(stderrTail('  one diagnostic  ')).toBe('one diagnostic');
+  });
+
+  it('strips ANSI escape sequences before remaining control characters', () => {
+    expect(stderrTail('\x1b[31mred\x1b[0m\x00')).toBe('red');
+    expect(stderrTail('\x1b]0;window title\x07visible')).toBe('visible');
+    expect(stderrTail('\x1b]0;window title\x1b\\visible')).toBe('visible');
+  });
+
+  it('splits CRLF, CR, and LF line endings', () => {
+    expect(stderrTail('one\r\ntwo\rthree\nfour')).toBe('one; two; three; four');
+  });
+
+  it('caps output at 600 code points without splitting surrogate pairs', () => {
+    const result = stderrTail(`${'a'.repeat(4)}😀${'b'.repeat(598)}`);
+
+    expect(result).toBe(`…😀${'b'.repeat(598)}`);
+    expect(Array.from(result)).toHaveLength(600);
+  });
+
+  it('returns an empty string for whitespace-only input', () => {
+    expect(stderrTail(' \t\r\n ')).toBe('');
+    expect(stderrTail('\x1b[31m\x1b[0m')).toBe('');
+  });
+});
 
 describe('Error Creation Functions', () => {
   describe('createAPICallError', () => {
@@ -20,7 +55,7 @@ describe('Error Creation Functions', () => {
       });
 
       expect(error).toBeInstanceOf(APICallError);
-      expect(error.message).toBe('Test error');
+      expect(error.message).toBe('Test error | stderr (tail): Command failed');
       expect(error.isRetryable).toBe(false);
       expect(error.data).toEqual({
         exitCode: 1,
@@ -47,6 +82,50 @@ describe('Error Creation Functions', () => {
       });
 
       expect(error.isRetryable).toBe(true);
+    });
+
+    it('appends a visible stderr tail when stderr has content', () => {
+      const error = createAPICallError({
+        message: 'CLI failed',
+        stderr: 'first line\nlast line',
+      });
+
+      expect(error.message).toBe('CLI failed | stderr (tail): first line; last line');
+    });
+
+    it.each([undefined, '', ' \t\r\n '])(
+      'does not append a dangling stderr marker for %j',
+      (stderr) => {
+        const error = createAPICallError({
+          message: 'CLI failed',
+          stderr,
+        });
+
+        expect(error.message).toBe('CLI failed');
+        expect(error.message).not.toContain(' | stderr (tail):');
+      }
+    );
+
+    it('does not append stderr twice when the marker is already present', () => {
+      const error = createAPICallError({
+        message: 'CLI failed | stderr (tail): existing detail',
+        stderr: 'new detail',
+      });
+
+      expect(error.message).toBe('CLI failed | stderr (tail): existing detail');
+    });
+
+    it('preserves stderr verbatim in data while capping only the visible tail', () => {
+      const stderr = `  original\n${'x'.repeat(700)}😀  `;
+      const error = createAPICallError({
+        message: 'CLI failed',
+        stderr,
+      });
+
+      expect((error.data as { stderr?: string }).stderr).toBe(stderr);
+      const visibleTail = error.message.split(' | stderr (tail): ')[1];
+      expect(visibleTail).toBeDefined();
+      expect(Array.from(visibleTail ?? '')).toHaveLength(600);
     });
   });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,39 @@
 import { APICallError, LoadAPIKeyError } from '@ai-sdk/provider';
 
+export const STDERR_TAIL_MARKER = ' | stderr (tail):';
+const ANSI_ESCAPE_SEQUENCE =
+  // eslint-disable-next-line no-control-regex
+  /\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~])/g;
+
+/**
+ * Converts stderr into a short, single-line tail suitable for error messages.
+ */
+export function stderrTail(raw: string): string {
+  const withoutAnsi = raw.replace(ANSI_ESCAPE_SEQUENCE, '');
+  const withoutControlCharacters = Array.from(withoutAnsi)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return (
+        character === '\r' ||
+        character === '\n' ||
+        codePoint === 0x2028 ||
+        codePoint === 0x2029 ||
+        (codePoint >= 0x20 && codePoint < 0x7f) ||
+        codePoint > 0x9f
+      );
+    })
+    .join('');
+  const tail = withoutControlCharacters
+    .split(/\r\n|\r|\n|\u2028|\u2029/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(-5)
+    .join('; ');
+  const codePoints = Array.from(tail);
+
+  return codePoints.length > 600 ? `…${codePoints.slice(-599).join('')}` : tail;
+}
+
 /**
  * Metadata associated with Claude Code SDK errors.
  * Provides additional context about command execution failures.
@@ -69,9 +103,14 @@ export function createAPICallError({
     stderr,
     promptExcerpt,
   };
+  const tail = typeof stderr === 'string' && stderr.length > 0 ? stderrTail(stderr) : '';
+  const enrichedMessage =
+    tail && !message.includes(STDERR_TAIL_MARKER)
+      ? `${message}${STDERR_TAIL_MARKER} ${tail}`
+      : message;
 
   return new APICallError({
-    message,
+    message: enrichedMessage,
     isRetryable,
     url: 'claude-code-cli://command',
     requestBodyValues: promptExcerpt ? { prompt: promptExcerpt } : undefined,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -132,11 +132,21 @@ export function createAPICallError({
  * });
  * ```
  */
-export function createAuthenticationError({ message }: { message: string }): LoadAPIKeyError {
-  return new LoadAPIKeyError({
+export function createAuthenticationError({
+  message,
+  stderr,
+}: {
+  message: string;
+  stderr?: string;
+}): LoadAPIKeyError {
+  const error = new LoadAPIKeyError({
     message:
       message || 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.',
   });
+  if (stderr) {
+    (error as LoadAPIKeyError & { data?: ClaudeCodeErrorMetadata }).data = { stderr };
+  }
+  return error;
 }
 
 /**
@@ -253,6 +263,9 @@ export function isTimeoutError(error: unknown): boolean {
 export function getErrorMetadata(error: unknown): ClaudeCodeErrorMetadata | undefined {
   if (error instanceof APICallError && error.data) {
     return error.data as ClaudeCodeErrorMetadata;
+  }
+  if (error instanceof LoadAPIKeyError && (error as LoadAPIKeyError & { data?: unknown }).data) {
+    return (error as LoadAPIKeyError & { data?: ClaudeCodeErrorMetadata }).data;
   }
   return undefined;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -158,16 +158,19 @@ export function createAuthenticationError({ message }: { message: string }): Loa
  */
 export function createTimeoutError({
   message,
+  stderr,
   promptExcerpt,
   timeoutMs,
 }: {
   message: string;
+  stderr?: string;
   promptExcerpt?: string;
   timeoutMs?: number;
 }): APICallError {
   // Store timeoutMs in metadata for potential use by error handlers
   const metadata: ClaudeCodeErrorMetadata = {
     code: 'TIMEOUT',
+    stderr,
     promptExcerpt,
   };
 


### PR DESCRIPTION
## Summary

Port of #136's fix to the 3.x (AI SDK v6) line — see #137 for the full write-up. `src/errors.ts` is byte-identical to #137's result (sha256-verified); the `handleClaudeCodeError`/collector changes apply the same logic to the v6 file.

- `createAPICallError` appends a single-line `stderr (tail): …` excerpt (ANSI-stripped, last 5 non-empty lines, 600-code-point cap) to the visible message, exactly once via a marker guard; `data.stderr` keeps the full capture.
- Auth classification also reads a high-precision stderr pattern list (login/API-key phrases only — incidental `401 Unauthorized` noise can't misclassify a crash as `LoadAPIKeyError`); timeout classification adds a narrow `request timed out`/`ETIMEDOUT` stderr pattern. Both carry the tail in their messages.
- Retained stderr capped at 4000 chars (both collectors and the SDK-provided value), code-point-safe.
- Release: 3.5.2 → 3.5.3 (`PROVIDER_VERSION` synced), CHANGELOG entry. Lockfile touched only in its two root version fields (`@anthropic-ai/claude-agent-sdk` still resolves 0.3.206).

## Testing

Ported `stderrTail` suite plus model-level tests (auth-from-stderr positive/negative, timeout narrow-pattern positive/negative, SDK-stderr precedence/whitespace fallback/capping, both collector sites). `npm run lint && npm run typecheck && npm test && npm run build` all pass (820 tests; CJS+ESM+DTS build).

Refs #136