### PR TITLE
feat: forward inline video file parts as base64 content blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This release ports the provider to AI SDK v7 / `LanguageModelV4`, adds first-cla
 
 Version 4.0.0 intentionally keeps optional provider surfaces absent unless the Claude Agent SDK has a durable provider-reference mapping:
 
-- `ProviderV4.files()` is not implemented yet. The AI SDK interface uploads `{ type: 'data' }` or `{ type: 'text' }` bytes and returns a reusable provider reference, but Claude Agent SDK `0.3.205` exposes no direct upload/reuse API for that contract. This provider forwards inline **image** file parts in prompts; non-image inline files (for example PDFs) emit an unsupported-file call warning and are not forwarded. It does not upload files into durable provider references.
+- `ProviderV4.files()` is not implemented yet. The AI SDK interface uploads `{ type: 'data' }` or `{ type: 'text' }` bytes and returns a reusable provider reference, but Claude Agent SDK `0.3.205` exposes no direct upload/reuse API for that contract. This provider forwards inline **image** and **video** file parts in prompts; other inline files (for example PDFs) emit an unsupported-file call warning and are not forwarded. It does not upload files into durable provider references.
 - Canonical V4 tool-result file parts are replayed into conversation history as text markers like `[File <name>: <mediaType>]`; raw file bytes are not re-sent on replay. Richer tool-result file replay, such as re-sending actual image/file bytes for tool-result file parts, is deferred.
 - `ProviderV4.skills()` is not implemented yet. Claude Code skills are loaded from configured user/project/local skill directories with the existing `skills` setting below; there is no Agent SDK API that uploads a skill bundle and returns an AI SDK provider reference.
 - Workflow serialization is deferred. `@ai-sdk/provider-utils@5.0.5` exposes `WORKFLOW_SERIALIZE`, `WORKFLOW_DESERIALIZE`, and `serializeModelOptions()` for provider model classes in the AI SDK v7 stack, but this provider has not added a serialization contract for provider instances or settings. Callback/function settings such as `canUseTool`, hooks, `logger`, `spawnClaudeCodeProcess`, and `SessionStore` methods are not JSON-serializable and must be recreated by the application.
@@ -574,6 +574,13 @@ See [examples/message-injection.ts](examples/message-injection.ts) for complete 
 - `streamingInput: 'off'` remains an explicit opt-out: image prompts skip the streaming-input path, image parts are omitted, and the provider emits a generic `type: 'other'` image streaming-input warning.
 - Use realistic image payloads—very small placeholders may result in the model asking for a different image.
 - `examples/images.ts` accepts a local image path, reads its bytes, and builds an AI SDK v7 file part: `npx tsx examples/images.ts /absolute/path/to/image.png`.
+
+## Video Inputs
+
+- Video file parts are forwarded inline as base64 `video` content blocks, mirroring the image path. They are sent through the Agent SDK streaming-input path, so `streamingInput: 'auto'` (the default) enables streaming input when video parts are present just as it does for images.
+- Supported payloads include data URLs (`data:video/mp4;base64,...`), strings prefixed with `base64:<mediaType>,<data>`, or AI SDK v7 file parts such as `{ type: 'file', data: { type: 'data', data: '<base64>' }, mediaType: 'video/mp4' }` (use `mediaType`, not `mimeType`).
+- Wildcard media types (`video/*` or `video`) are resolved to a concrete type from the bytes when possible; undetectable payloads warn and are skipped.
+- Remote HTTP(S) video URLs are ignored with the warning "Video URLs are not supported by this provider; supply base64/data URLs." Inline base64/data URLs are required.
 
 ## Skills Support
 

--- a/src/convert-to-claude-code-messages.test.ts
+++ b/src/convert-to-claude-code-messages.test.ts
@@ -145,7 +145,7 @@ describe('convertToClaudeCodeMessages', () => {
 
     expect(result.messagesPrompt).toBe('Human: Check this file:');
     expect(result.warnings).toContain(
-      'Unsupported file part (application/pdf) was ignored; this provider forwards only image file parts inline.'
+      'Unsupported file part (application/pdf) was ignored; this provider forwards only image and video file parts inline.'
     );
   });
 

--- a/src/convert-to-claude-code-messages.ts
+++ b/src/convert-to-claude-code-messages.ts
@@ -26,12 +26,14 @@ interface FileConversionResult {
 
 const IMAGE_URL_WARNING = 'Image URLs are not supported by this provider; supply base64/data URLs.';
 const IMAGE_CONVERSION_WARNING = 'Unable to convert image content; supply base64/data URLs.';
+const VIDEO_URL_WARNING = 'Video URLs are not supported by this provider; supply base64/data URLs.';
+const VIDEO_CONVERSION_WARNING = 'Unable to convert video content; supply base64/data URLs.';
 const FILE_REFERENCE_WARNING =
   'Provider file references are not supported by this provider; supply inline file data.';
 
 function createUnsupportedFilePartWarning(mediaType: string | undefined): string {
   const mediaTypeLabel = mediaType && mediaType.trim() ? mediaType : 'unknown';
-  return `Unsupported file part (${mediaTypeLabel}) was ignored; this provider forwards only image file parts inline.`;
+  return `Unsupported file part (${mediaTypeLabel}) was ignored; this provider forwards only image and video file parts inline.`;
 }
 
 /**
@@ -200,6 +202,108 @@ function parseStringImage(
   return { warning: IMAGE_CONVERSION_WARNING };
 }
 
+function isVideoMimeType(mediaType?: string): boolean {
+  if (!mediaType) {
+    return false;
+  }
+  const normalized = normalizeMediaType(mediaType);
+  return normalized === 'video' || normalized === 'video/*' || normalized.startsWith('video/');
+}
+
+function isConcreteVideoMimeType(mediaType: string): boolean {
+  const normalized = normalizeMediaType(mediaType);
+  return normalized.startsWith('video/') && !normalized.endsWith('/*');
+}
+
+function resolveVideoMediaType(mediaType: string, data?: Uint8Array | string): string | undefined {
+  const normalizedMediaType = normalizeMediaType(mediaType);
+
+  if (isConcreteVideoMimeType(normalizedMediaType)) {
+    return normalizedMediaType;
+  }
+
+  if ((normalizedMediaType === 'video' || normalizedMediaType === 'video/*') && data) {
+    try {
+      const detectedMediaType = detectMediaType({ data, topLevelType: 'video' });
+      if (detectedMediaType && isConcreteVideoMimeType(detectedMediaType)) {
+        return detectedMediaType;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function createVideoContent(mediaType: string, data: string): SDKUserContentPart | undefined {
+  const normalizedType = normalizeMediaType(mediaType);
+  const trimmedData = data.trim().replace(/\s+/g, '');
+
+  if (!isConcreteVideoMimeType(normalizedType) || !trimmedData) {
+    return undefined;
+  }
+
+  return {
+    type: 'video',
+    source: {
+      type: 'base64',
+      media_type: normalizedType,
+      data: trimmedData,
+    },
+  } as unknown as SDKUserContentPart;
+}
+
+function resolveStringVideoMediaType(
+  mediaType: string,
+  data: string,
+  fallbackMimeType?: string
+): string | undefined {
+  return (
+    resolveVideoMediaType(mediaType, data) ??
+    (fallbackMimeType ? resolveVideoMediaType(fallbackMimeType, data) : undefined)
+  );
+}
+
+function parseStringVideo(
+  value: string,
+  fallbackMimeType?: string
+): { content?: SDKUserContentPart; warning?: string } {
+  const trimmed = value.trim();
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return { warning: VIDEO_URL_WARNING };
+  }
+
+  const dataUrlMatch = trimmed.match(/^data:([^;]+);base64,(.+)$/i);
+  if (dataUrlMatch) {
+    const [, mediaType, data] = dataUrlMatch;
+    const resolvedMediaType = resolveStringVideoMediaType(mediaType, data, fallbackMimeType);
+    const content = resolvedMediaType ? createVideoContent(resolvedMediaType, data) : undefined;
+    return content ? { content } : { warning: VIDEO_CONVERSION_WARNING };
+  }
+
+  const base64Match = trimmed.match(/^base64:([^,]+),(.+)$/i);
+  if (base64Match) {
+    const [, explicitMimeType, data] = base64Match;
+    const resolvedMediaType = resolveStringVideoMediaType(explicitMimeType, data, fallbackMimeType);
+    const content = resolvedMediaType ? createVideoContent(resolvedMediaType, data) : undefined;
+    return content ? { content } : { warning: VIDEO_CONVERSION_WARNING };
+  }
+
+  if (fallbackMimeType) {
+    const resolvedMediaType = resolveVideoMediaType(fallbackMimeType, trimmed);
+    if (resolvedMediaType) {
+      const content = createVideoContent(resolvedMediaType, trimmed);
+      if (content) {
+        return { content };
+      }
+    }
+  }
+
+  return { warning: VIDEO_CONVERSION_WARNING };
+}
+
 function convertBinaryToBase64(data: Uint8Array | ArrayBuffer): string | undefined {
   if (typeof Buffer !== 'undefined') {
     const buffer =
@@ -229,39 +333,75 @@ function parseFilePart(part: FileLikePart): FileConversionResult {
 
   switch (fileData.type) {
     case 'data': {
-      if (!mediaType || !isImageMimeType(mediaType)) {
+      if (!mediaType) {
         return { warning: createUnsupportedFilePartWarning(mediaType) };
       }
 
-      if (typeof fileData.data === 'string') {
-        return parseStringImage(fileData.data, mediaType);
+      if (isImageMimeType(mediaType)) {
+        if (typeof fileData.data === 'string') {
+          return parseStringImage(fileData.data, mediaType);
+        }
+
+        const resolvedMediaType = resolveImageMediaType(mediaType, fileData.data);
+        if (!resolvedMediaType) {
+          return { warning: IMAGE_CONVERSION_WARNING };
+        }
+
+        const base64 = convertBinaryToBase64(fileData.data);
+        if (!base64) {
+          return { warning: IMAGE_CONVERSION_WARNING };
+        }
+        const content = createImageContent(resolvedMediaType, base64);
+        return content ? { content } : { warning: IMAGE_CONVERSION_WARNING };
       }
 
-      const resolvedMediaType = resolveImageMediaType(mediaType, fileData.data);
-      if (!resolvedMediaType) {
-        return { warning: IMAGE_CONVERSION_WARNING };
+      if (isVideoMimeType(mediaType)) {
+        if (typeof fileData.data === 'string') {
+          return parseStringVideo(fileData.data, mediaType);
+        }
+
+        const resolvedMediaType = resolveVideoMediaType(mediaType, fileData.data);
+        if (!resolvedMediaType) {
+          return { warning: VIDEO_CONVERSION_WARNING };
+        }
+
+        const base64 = convertBinaryToBase64(fileData.data);
+        if (!base64) {
+          return { warning: VIDEO_CONVERSION_WARNING };
+        }
+        const content = createVideoContent(resolvedMediaType, base64);
+        return content ? { content } : { warning: VIDEO_CONVERSION_WARNING };
       }
 
-      const base64 = convertBinaryToBase64(fileData.data);
-      if (!base64) {
-        return { warning: IMAGE_CONVERSION_WARNING };
-      }
-      const content = createImageContent(resolvedMediaType, base64);
-      return content ? { content } : { warning: IMAGE_CONVERSION_WARNING };
+      return { warning: createUnsupportedFilePartWarning(mediaType) };
     }
 
     case 'url': {
-      if (!mediaType || !isImageMimeType(mediaType)) {
+      if (!mediaType) {
         return { warning: createUnsupportedFilePartWarning(mediaType) };
       }
-      const url = fileData.url.toString();
-      // Only data: URLs carry inline bytes; other schemes (http, file, blob, ...)
-      // must not reach parseStringImage's fallback, which would wrap the URL
-      // string itself as base64 image data.
-      if (!/^data:/i.test(url.trim())) {
-        return { warning: IMAGE_URL_WARNING };
+
+      if (isImageMimeType(mediaType)) {
+        const url = fileData.url.toString();
+        // Only data: URLs carry inline bytes; other schemes (http, file, blob, ...)
+        // must not reach parseStringImage's fallback, which would wrap the URL
+        // string itself as base64 image data.
+        if (!/^data:/i.test(url.trim())) {
+          return { warning: IMAGE_URL_WARNING };
+        }
+        return parseStringImage(url, mediaType);
       }
-      return parseStringImage(url, mediaType);
+
+      if (isVideoMimeType(mediaType)) {
+        const url = fileData.url.toString();
+        // Only data: URLs carry inline bytes; remote video URLs are not fetched.
+        if (!/^data:/i.test(url.trim())) {
+          return { warning: VIDEO_URL_WARNING };
+        }
+        return parseStringVideo(url, mediaType);
+      }
+
+      return { warning: createUnsupportedFilePartWarning(mediaType) };
     }
 
     case 'text':
@@ -376,7 +516,7 @@ function serializeToolResultOutput(
  * ```
  *
  * @remarks
- * - Image parts are collected for streaming input; unsupported variants produce warnings
+ * - Image and video parts are collected for streaming input; unsupported variants produce warnings
  * - Tool calls are serialized one per line as `[Tool call: name({...input})]`
  *   (inputs truncated at 1000 characters), pairing with `Tool Result (name): ...` lines
  * - JSON schema enforcement is handled natively by the SDK's outputFormat option (v0.1.45+)

--- a/src/convert-to-claude-code-messages.videos.test.ts
+++ b/src/convert-to-claude-code-messages.videos.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { convertToClaudeCodeMessages } from './convert-to-claude-code-messages.js';
+
+describe('convertToClaudeCodeMessages (videos)', () => {
+  it('includes data URL videos in streaming content', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Here is a sample video.' },
+          {
+            type: 'file',
+            mediaType: 'video/mp4',
+            data: { type: 'url', url: new URL('data:video/mp4;base64,aGVsbG8=') },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts).toHaveLength(2);
+    expect(result.streamingContentParts[0]).toEqual({
+      type: 'text',
+      text: 'Human: Here is a sample video.',
+    });
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'video',
+      source: {
+        type: 'base64',
+        media_type: 'video/mp4',
+        data: 'aGVsbG8=',
+      },
+    });
+  });
+
+  it('includes base64 videos when a concrete media type is provided', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Inline base64 video.' },
+          { type: 'file', mediaType: 'video/quicktime', data: { type: 'data', data: 'AQID' } },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'video',
+      source: {
+        type: 'base64',
+        media_type: 'video/quicktime',
+        data: 'AQID',
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: 'wildcard byte',
+      mediaType: 'video/*',
+      data: new Uint8Array([0, 0, 0, 32, 102, 116, 121, 112]),
+      expectedMediaType: 'video/mp4',
+      expectedBase64: 'AAAAIGZ0eXA=',
+    },
+    {
+      label: 'top-level byte',
+      mediaType: 'video',
+      data: new Uint8Array([0, 0, 0, 32, 102, 116, 121, 112]),
+      expectedMediaType: 'video/mp4',
+      expectedBase64: 'AAAAIGZ0eXA=',
+    },
+    {
+      label: 'wildcard base64',
+      mediaType: 'video/*',
+      data: 'AAAAIGZ0eXA=',
+      expectedMediaType: 'video/mp4',
+      expectedBase64: 'AAAAIGZ0eXA=',
+    },
+    {
+      label: 'wildcard data URL',
+      mediaType: 'video/*',
+      data: 'data:video/*;base64,AAAAIGZ0eXA=',
+      expectedMediaType: 'video/mp4',
+      expectedBase64: 'AAAAIGZ0eXA=',
+    },
+    {
+      label: 'wildcard provider base64',
+      mediaType: 'video/*',
+      data: 'base64:video/*,AAAAIGZ0eXA=',
+      expectedMediaType: 'video/mp4',
+      expectedBase64: 'AAAAIGZ0eXA=',
+    },
+  ])(
+    'detects concrete video media type for $label data',
+    ({ mediaType, data, expectedMediaType, expectedBase64 }) => {
+      const prompt = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Detected video.' },
+            { type: 'file', mediaType, data: { type: 'data', data } },
+          ],
+        },
+      ] satisfies LanguageModelV4Prompt;
+
+      const result = convertToClaudeCodeMessages(prompt);
+
+      expect(result.warnings).toBeUndefined();
+      expect(result.hasImageParts).toBe(true);
+      expect(result.streamingContentParts[1]).toEqual({
+        type: 'video',
+        source: {
+          type: 'base64',
+          media_type: expectedMediaType,
+          data: expectedBase64,
+        },
+      });
+    }
+  );
+
+  it('encodes only the selected Uint8Array view range for byte videos', () => {
+    const backingBytes = new Uint8Array([0, 0, 0, 32, 102, 116, 121, 112, 0, 0]);
+    const videoBytes = backingBytes.subarray(0, 8);
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Subarray video.' },
+          { type: 'file', mediaType: 'video/*', data: { type: 'data', data: videoBytes } },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(result.streamingContentParts[1]).toEqual({
+      type: 'video',
+      source: {
+        type: 'base64',
+        media_type: 'video/mp4',
+        data: 'AAAAIGZ0eXA=',
+      },
+    });
+  });
+
+  it('warns when generic video byte data cannot be detected', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Unknown video.' },
+          {
+            type: 'file',
+            mediaType: 'video/*',
+            data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.hasImageParts).toBe(false);
+    expect(result.warnings).toContain('Unable to convert video content; supply base64/data URLs.');
+    expect(result.streamingContentParts).toHaveLength(1);
+  });
+
+  it('warns and skips HTTP video URLs', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Remote video' },
+          {
+            type: 'file',
+            mediaType: 'video/mp4',
+            data: { type: 'url', url: new URL('https://example.com/clip.mp4') },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.hasImageParts).toBe(false);
+    expect(result.warnings).toContain(
+      'Video URLs are not supported by this provider; supply base64/data URLs.'
+    );
+    expect(result.streamingContentParts).toHaveLength(1);
+  });
+
+  it('warns and skips non-data video URL schemes instead of encoding the URL string', () => {
+    const prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Local video' },
+          {
+            type: 'file',
+            mediaType: 'video/mp4',
+            data: { type: 'url', url: new URL('file:///tmp/clip.mp4') },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.hasImageParts).toBe(false);
+    expect(result.warnings).toContain(
+      'Video URLs are not supported by this provider; supply base64/data URLs.'
+    );
+    expect(result.streamingContentParts).toHaveLength(1);
+    expect(JSON.stringify(result.streamingContentParts)).not.toContain('file:///tmp/clip.mp4');
+  });
+
+  it('forwards video file parts from assistant history into streaming content', () => {
+    const prompt = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Attached clip.' },
+          {
+            type: 'file',
+            mediaType: 'video/mp4',
+            data: { type: 'data', data: 'aGVsbG8=' },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt;
+
+    const result = convertToClaudeCodeMessages(prompt);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.hasImageParts).toBe(true);
+    expect(
+      (
+        result.streamingContentParts as Array<{
+          type: string;
+          source?: { type?: string; media_type?: string };
+        }>
+      ).some(
+        (part) =>
+          part.type === 'video' &&
+          part.source?.type === 'base64' &&
+          part.source?.media_type === 'video/mp4'
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Reason: Add video file conversion so models that accept video input receive inline video file parts instead of discarding them.

## What changed

`convertToClaudeCodeMessages` previously forwarded only inline **image** file parts in prompts and discarded every other inline file (including video) with an `Unsupported file part` warning. This adds inline **video** file part conversion, mirroring the existing image path:

- Adds `isVideoMimeType`, `isConcreteVideoMimeType`, `resolveVideoMediaType`, `createVideoContent`, `resolveStringVideoMediaType`, and `parseStringVideo` helpers that parallel the image equivalents.
- `parseFilePart` now resolves a concrete video media type (from the file part media type or via byte-signature detection when a wildcard `video/*`/`video` type is supplied) and forwards the video bytes inline as a base64 `video` content block through the streaming-input content parts.
- Data URLs, `base64:<mediaType>,<data>` strings, and AI SDK v7 file parts with `{ type: 'data' }` bytes or `{ type: 'url' }` data URLs are all handled, consistent with image handling.
- Remote HTTP(S)/file video URLs are still not fetched and emit `Video URLs are not supported by this provider; supply base64/data URLs.`
- The unsupported-file warning now states the provider forwards only image and video file parts inline.

## Why

Models reachable through the Anthropic-compatible base URL can accept `video` content blocks. Without this conversion, video input in AI SDK v7 prompts is dropped before it reaches the model.

## Checks

- `npm run typecheck`
- `npm run lint:all`
- `npm run format:check`
- `npm run build`
- `npm run test` (full suite, 992 tests across node and edge projects)

A new `src/convert-to-claude-code-messages.videos.test.ts` suite covers data URL videos, concrete base64 videos, wildcard media-type detection (byte, base64, data URL, provider base64), subarray view encoding, undetectable-byte warnings, remote/non-data URL warnings, and assistant-history video forwarding. The existing PDF unsupported-file warning expectation was updated to match the new message wording.
