### PR TITLE
fix(ci): repair invalid secrets gate in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,12 @@ on:
 jobs:
   review-with-tracking:
     runs-on: ubuntu-latest
-    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    # The secrets context is not allowed in a job-level `if` — gating on
+    # secrets.CLAUDE_CODE_OAUTH_TOKEN made the whole workflow file invalid, so
+    # GitHub reported a 0-second "workflow file issue" failure on every push.
+    # Gate on fork PRs instead: forks are exactly the case where the secret is
+    # unavailable, so skip them cleanly rather than fail in the action.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Every push to every branch has been getting a red X from a 0-second `.github/workflows/claude-code-review.yml` failure ("This run likely failed because of a workflow file issue") — visible on the #143 merge commit, but the failures go back to at least July 11 and predate today's changes.

## Root cause

The job-level gate `if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}` uses the `secrets` context, which is not available in `jobs.<job_id>.if`. That makes the whole workflow file invalid, so GitHub reports a validation failure on every push (even though the workflow only declares a `pull_request` trigger), and the intended PR review job never runs at all.

## Fix

Gate on `!github.event.pull_request.head.repo.fork` instead. Fork PRs are exactly the case where the secret is unavailable, so they skip cleanly; same-repo PRs proceed (the `CLAUDE_CODE_OAUTH_TOKEN` secret is confirmed present in this repo). This matches `claude.yml`, which uses no secrets-based gate and works.

## Verification

YAML parses. Once merged, pushes should stop producing the stub failure, and this PR itself should trigger the review action as a live test of the `pull_request` path.