### PR TITLE
fix(ci): skip Claude review for Dependabot-triggered runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,12 @@ jobs:
     # The secrets context is not allowed in a job-level `if` — gating on
     # secrets.CLAUDE_CODE_OAUTH_TOKEN made the whole workflow file invalid, so
     # GitHub reported a 0-second "workflow file issue" failure on every push.
-    # Gate on fork PRs instead: forks are exactly the case where the secret is
-    # unavailable, so skip them cleanly rather than fail in the action.
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # Gate on the cases where secrets are actually withheld instead, so they
+    # skip cleanly rather than fail in the action: fork PRs, and runs
+    # triggered by Dependabot (its branches are same-repo so the fork check
+    # misses them; the actor check still lets the review run when a human
+    # triggers the workflow on a Dependabot PR, e.g. via the labeled event).
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Follow-up to #145, addressing the [Codex P2 finding](https://github.com/ben-vargas/ai-sdk-provider-claude-code/pull/145#pullrequestreview-4895015546) that arrived after merge.

Dependabot PR branches live in this repository, so `!head.repo.fork` lets the review job run — but GitHub withholds secrets from Dependabot-triggered workflow runs, so the action would fail with an empty `CLAUDE_CODE_OAUTH_TOKEN` instead of skipping cleanly.

Add `github.actor != 'dependabot[bot]'` to the gate. The actor check matches exactly the runs where secrets are withheld: a Dependabot-triggered `opened`/`synchronize` run skips, while a human labeling a Dependabot PR (the `labeled` trigger) still gets a review because the human is the actor and secrets are available.

Dependabot isn't currently enabled on this repo, so this is preemptive hardening — workflow-only, no release impact.