### PR TITLE
feat: map account_on_hold/billing_error to structured, actionable errors (preserve errorKind)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`errorKind` on `ClaudeCodeErrorMetadata`** ([#155](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/155)) - The structured SDK assistant error kind (`SDKAssistantMessageError`, e.g. `'account_on_hold'`, `'billing_error'`, `'overloaded'`) is now preserved on every mapped error path: authentication `LoadAPIKeyError`s, timeouts, retryable overload/rate-limit errors, model-not-found, and the generic fallback. The field is set only when the SDK delivered the kind structurally — heuristic (message/stderr text) classifications never fabricate one. Typed as open `string` so future SDK kinds flow through without a type-level break.
+- **`isAccountStateError()` helper** ([#155](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/155)) - Returns true exactly when the metadata carries the structured kind `'account_on_hold'` or `'billing_error'` on an `APICallError`. These are account-state problems resolved in the Anthropic Console, not credential problems — they are `APICallError`, never `LoadAPIKeyError`, and never satisfy `isAuthenticationError()`.
+- **`SDKAssistantMessageError` type re-export** - The SDK's current known-value union of structured assistant error kinds, for consumers narrowing `errorKind`.
+- **Actionable `account_on_hold` / `billing_error` mapping** ([#155](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/155)) - Structurally reported account-state kinds now map to non-retryable `APICallError`s with console guidance, classified before the auth-substring heuristics so account-state error text mentioning "unauthorized" cannot be misrouted to re-authentication.
 - **`perTaskStopAffordance` setting** ([#153](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/153)) - Maps the Agent SDK's new `perTaskStopAffordance` option: a capability assertion that the host app renders per-task stop controls wired to `stopTask()`, so an interrupt on a live open-input query spares running background tasks and only aborts the current turn. Unset means the SDK's fail-closed default (interrupt kills background tasks); one-shot (closed-input) requests kill held-back tasks on interrupt regardless.
 - **Completed hook type re-exports** - Re-exports `PreModelSwitchHookInput`, `PostModelSwitchHookInput`, `PreModelSwitchHookSpecificOutput`, and `PostModelSwitchHookSpecificOutput` (new in SDK 0.3.251) plus the previously missing `DirectoryAddedHookInput`, restoring the "every member of the SDK `HookInput` union" guarantee, with a compile-time entry-point check.
 
 ### Changed
 
+- **Account-state error messages** - Structurally reported `account_on_hold` / `billing_error` failures now carry actionable Anthropic Console guidance appended to the original SDK message (previously generic fall-through text). Retryability and error classes for all previously mapped kinds are unchanged.
 - **Claude Agent SDK pinned at `0.3.251`** - Bumps the exact `@anthropic-ai/claude-agent-sdk` pin from `0.3.232`, resolving the weekly canary's Options drift guard failure ([#153](https://github.com/ben-vargas/ai-sdk-provider-claude-code/issues/153)). `perTaskStopAffordance` was the only new `Options` key (64 → 65); typecheck and the unit suite pass against the new pin.
 
 ### Inherited upstream behavior changes
 
-- Because this bump replaces the bundled Agent SDK runtime, 0.3.232 → 0.3.251 behavior changes are inherited. Notably, an `AgentDefinition` that omits `model` now uses a configured default subagent model before falling back to the parent model. New hook events `PreModelSwitch`/`PostModelSwitch` and the `account_on_hold` assistant error kind (currently mapped to a generic non-retryable error, like `billing_error`) also arrive with this runtime.
+- Because this bump replaces the bundled Agent SDK runtime, 0.3.232 → 0.3.251 behavior changes are inherited. Notably, an `AgentDefinition` that omits `model` now uses a configured default subagent model before falling back to the parent model. New hook events `PreModelSwitch`/`PostModelSwitch` and the `account_on_hold` assistant error kind (mapped to an actionable non-retryable error in this release, together with `billing_error` — see Added above) also arrive with this runtime.
 
 ## [4.1.1] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -725,6 +725,32 @@ try {
 
 The metadata accessor returns the full captured stderr, capped at 4000 characters. Authentication and timeout failures are also classified when the only evidence is in stderr, using high-precision matching to avoid false positives from unrelated stderr output.
 
+When the Agent SDK reports a structured assistant error kind (`SDKAssistantMessageError`, e.g. `'account_on_hold'`, `'billing_error'`, `'overloaded'`, `'rate_limit'`), `getErrorMetadata()` returns it as `errorKind` on every mapped error path — and `undefined` otherwise: heuristic classifications from message/stderr text never fabricate one. Check the value (not key presence), and prefer `getErrorMetadata(error)` over casting `error.data` directly. Unrecognized future kinds fall through to the existing message/stderr/exit-code heuristics and land on the generic non-retryable path only when no heuristic matches — either way the kind remains visible in `errorKind`.
+
+Account-state failures — `account_on_hold` and `billing_error` — map to non-retryable `APICallError`s with actionable guidance. They are **not** credential failures: re-authenticating will not fix them; resolve the hold or billing issue in the [Anthropic Console](https://console.anthropic.com). Check for them with `isAccountStateError()` **before** the authentication branch:
+
+```ts
+import { generateText } from 'ai';
+import {
+  claudeCode,
+  getErrorMetadata,
+  isAccountStateError,
+  isAuthenticationError,
+} from 'ai-sdk-provider-claude-code';
+
+try {
+  await generateText({ model: claudeCode('sonnet'), prompt: 'Hello!' });
+} catch (error) {
+  if (isAccountStateError(error)) {
+    // Account-state problem — fix in the Anthropic Console, do not re-authenticate
+    const kind = getErrorMetadata(error)?.errorKind; // 'account_on_hold' | 'billing_error'
+    console.error(kind === 'account_on_hold' ? 'Account on hold' : 'Billing problem');
+  } else if (isAuthenticationError(error)) {
+    console.error('Re-authenticate the Claude Code SDK');
+  }
+}
+```
+
 ## Tool Error Parity (Streaming)
 
 - AI SDK v7 represents failed tool executions with the standard `tool-result` stream event/part and `isError: true`.

--- a/src/claude-code-language-model.test.ts
+++ b/src/claude-code-language-model.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { ClaudeCodeLanguageModel } from './claude-code-language-model.js';
-import { getErrorMetadata, isAuthenticationError } from './errors.js';
+import {
+  getErrorMetadata,
+  isAccountStateError,
+  isAuthenticationError,
+  isTimeoutError,
+} from './errors.js';
 import type {
   ClaudeCodeHookEvent,
   ClaudeCodeMcpStatusEvent,
@@ -3274,6 +3279,26 @@ describe('ClaudeCodeLanguageModel', () => {
       expect((thrownError as APICallError).isRetryable).toBe(true);
       // SDKResultError detail comes from errors[], not the missing result field
       expect((thrownError as APICallError).message).toContain('API request failed');
+      expect(getErrorMetadata(thrownError)?.errorKind).toBe('overloaded');
+    });
+
+    it('should classify structured rate_limit result errors as retryable with the kind preserved', async () => {
+      vi.mocked(mockQuery).mockReturnValue(
+        structuredErrorResponse('rate_limit', ['Request failed with status 429']) as any
+      );
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect((thrownError as APICallError).isRetryable).toBe(true);
+      expect(getErrorMetadata(thrownError)?.errorKind).toBe('rate_limit');
     });
 
     it('should classify structured model_not_found result errors as non-retryable', async () => {
@@ -3293,25 +3318,31 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(thrownError).toBeInstanceOf(APICallError);
       expect((thrownError as APICallError).isRetryable).toBe(false);
       expect((thrownError as APICallError).message).toContain('model was not found');
+      expect(getErrorMetadata(thrownError)?.errorKind).toBe('model_not_found');
     });
 
-    it('should classify structured oauth_org_not_allowed result errors as authentication errors', async () => {
-      vi.mocked(mockQuery).mockReturnValue(
-        structuredErrorResponse('oauth_org_not_allowed', ['Request failed with status 403']) as any
-      );
+    it.each(['oauth_org_not_allowed', 'authentication_failed'])(
+      'should classify structured %s result errors as authentication errors with the kind preserved',
+      async (kind) => {
+        vi.mocked(mockQuery).mockReturnValue(
+          structuredErrorResponse(kind, ['Request failed with status 403']) as any
+        );
 
-      let thrownError: unknown;
-      try {
-        await model.doGenerate({
-          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
-        });
-      } catch (e) {
-        thrownError = e;
+        let thrownError: unknown;
+        try {
+          await model.doGenerate({
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+          });
+        } catch (e) {
+          thrownError = e;
+        }
+
+        expect(thrownError).toBeDefined();
+        expect(thrownError).toBeInstanceOf(LoadAPIKeyError);
+        expect(isAuthenticationError(thrownError)).toBe(true);
+        expect(getErrorMetadata(thrownError)?.errorKind).toBe(kind);
       }
-
-      expect(thrownError).toBeDefined();
-      expect(isAuthenticationError(thrownError)).toBe(true);
-    });
+    );
 
     it('should emit a retryable error chunk for structured overloaded errors in streaming', async () => {
       vi.mocked(mockQuery).mockReturnValue(
@@ -3337,6 +3368,222 @@ describe('ClaudeCodeLanguageModel', () => {
       expect(errorChunk!.error).toBeInstanceOf(APICallError);
       expect((errorChunk!.error as APICallError).isRetryable).toBe(true);
       expect((errorChunk!.error as APICallError).message).toContain('API request failed');
+    });
+
+    // Account-state kinds (issue #155): billing hold / billing failure.
+    // Non-retryable APICallError with console guidance — never LoadAPIKeyError,
+    // because re-authenticating cannot fix the account.
+    const ACCOUNT_ON_HOLD_GUIDANCE =
+      'Your Anthropic account is on hold, so requests are being rejected. Resolve the hold in the Anthropic Console (https://console.anthropic.com), then retry — signing in again will not fix this.';
+    const BILLING_ERROR_GUIDANCE =
+      'A billing problem on your Anthropic account is blocking requests. Resolve the billing issue in the Anthropic Console (https://console.anthropic.com), then retry — signing in again will not fix this.';
+
+    it.each([
+      ['account_on_hold', ACCOUNT_ON_HOLD_GUIDANCE],
+      ['billing_error', BILLING_ERROR_GUIDANCE],
+    ])(
+      'should map structured %s result errors to actionable non-retryable APICallErrors',
+      async (kind, guidance) => {
+        vi.mocked(mockQuery).mockReturnValue(
+          structuredErrorResponse(kind, ['Request failed with status 402']) as any
+        );
+
+        let thrownError: unknown;
+        try {
+          await model.doGenerate({
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+          });
+        } catch (e) {
+          thrownError = e;
+        }
+
+        expect(thrownError).toBeInstanceOf(APICallError);
+        expect(thrownError).not.toBeInstanceOf(LoadAPIKeyError);
+        expect((thrownError as APICallError).isRetryable).toBe(false);
+        expect((thrownError as APICallError).message).toBe(
+          `Request failed with status 402. ${guidance}`
+        );
+        expect(isAuthenticationError(thrownError)).toBe(false);
+        expect(isAccountStateError(thrownError)).toBe(true);
+        expect(getErrorMetadata(thrownError)?.errorKind).toBe(kind);
+      }
+    );
+
+    it('should classify structured account_on_hold errors before the auth-substring heuristics', async () => {
+      vi.mocked(mockQuery).mockReturnValue(
+        structuredErrorResponse('account_on_hold', ['Request unauthorized: account on hold']) as any
+      );
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect(thrownError).not.toBeInstanceOf(LoadAPIKeyError);
+      expect(isAuthenticationError(thrownError)).toBe(false);
+      expect(isAccountStateError(thrownError)).toBe(true);
+    });
+
+    it.each([
+      ['billing_error', 'upstream flagged account_on_hold for this org', BILLING_ERROR_GUIDANCE],
+      ['account_on_hold', 'upstream flagged billing_error for this org', ACCOUNT_ON_HOLD_GUIDANCE],
+    ])(
+      'should keep the structured kind %s authoritative over conflicting message text',
+      async (kind, errorsText, guidance) => {
+        vi.mocked(mockQuery).mockReturnValue(structuredErrorResponse(kind, [errorsText]) as any);
+
+        let thrownError: unknown;
+        try {
+          await model.doGenerate({
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+          });
+        } catch (e) {
+          thrownError = e;
+        }
+
+        expect(thrownError).toBeInstanceOf(APICallError);
+        expect((thrownError as APICallError).message).toBe(`${errorsText}. ${guidance}`);
+        expect(getErrorMetadata(thrownError)?.errorKind).toBe(kind);
+      }
+    );
+
+    it('should not treat account-state tokens in message text as account-state errors without a structured kind', async () => {
+      vi.mocked(mockQuery).mockImplementation(() => {
+        throw new Error('API error: billing_error');
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      expect((thrownError as APICallError).isRetryable).toBe(false);
+      expect((thrownError as APICallError).message).not.toContain('console.anthropic.com');
+      expect((thrownError as APICallError).message).not.toContain('Anthropic Console');
+      expect(getErrorMetadata(thrownError)?.errorKind).toBeUndefined();
+      expect(isAccountStateError(thrownError)).toBe(false);
+    });
+
+    it('should preserve the structured kind when message text routes to the timeout branch', async () => {
+      vi.mocked(mockQuery).mockReturnValue(
+        structuredErrorResponse('unknown', ['Gateway timeout while routing request']) as any
+      );
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(isTimeoutError(thrownError)).toBe(true);
+      expect((thrownError as APICallError).isRetryable).toBe(true);
+      expect(getErrorMetadata(thrownError)?.code).toBe('TIMEOUT');
+      expect(getErrorMetadata(thrownError)?.errorKind).toBe('unknown');
+    });
+
+    it.each(['server_error', 'future_sdk_kind'])(
+      'should fall through unmapped structured kind %s to a generic non-retryable error with the kind preserved',
+      async (kind) => {
+        vi.mocked(mockQuery).mockReturnValue(
+          structuredErrorResponse(kind, ['Internal server error']) as any
+        );
+
+        let thrownError: unknown;
+        try {
+          await model.doGenerate({
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+          });
+        } catch (e) {
+          thrownError = e;
+        }
+
+        expect(thrownError).toBeInstanceOf(APICallError);
+        expect(thrownError).not.toBeInstanceOf(LoadAPIKeyError);
+        expect((thrownError as APICallError).isRetryable).toBe(false);
+        expect((thrownError as APICallError).message).not.toContain('Anthropic Console');
+        expect((thrownError as APICallError).message).not.toContain('model was not found');
+        expect((thrownError as APICallError).message).not.toContain('authenticated');
+        expect(getErrorMetadata(thrownError)?.errorKind).toBe(kind);
+        expect(isAccountStateError(thrownError)).toBe(false);
+        expect(isAuthenticationError(thrownError)).toBe(false);
+      }
+    );
+
+    it.each([
+      ['account_on_hold', ACCOUNT_ON_HOLD_GUIDANCE],
+      ['billing_error', BILLING_ERROR_GUIDANCE],
+    ])(
+      'should emit a non-retryable error chunk for structured %s errors in streaming',
+      async (kind, guidance) => {
+        vi.mocked(mockQuery).mockReturnValue(
+          structuredErrorResponse(kind, ['Request failed with status 402']) as any
+        );
+
+        const result = await model.doStream({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+
+        const chunks: ExtendedStreamPart[] = [];
+        const reader = result.stream.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+
+        const errorChunk = chunks.find((chunk) => chunk.type === 'error') as
+          | { type: 'error'; error: unknown }
+          | undefined;
+        expect(errorChunk).toBeDefined();
+        expect(errorChunk!.error).toBeInstanceOf(APICallError);
+        expect((errorChunk!.error as APICallError).isRetryable).toBe(false);
+        expect((errorChunk!.error as APICallError).message).toBe(
+          `Request failed with status 402. ${guidance}`
+        );
+        expect(getErrorMetadata(errorChunk!.error)?.errorKind).toBe(kind);
+        expect(isAccountStateError(errorChunk!.error)).toBe(true);
+      }
+    );
+
+    it('should append the stderr tail once to account-state errors and keep full stderr in metadata', async () => {
+      vi.mocked(mockQuery).mockImplementation(({ options }: any) => {
+        options?.stderr?.('Billing hold diagnostic line\n');
+        return structuredErrorResponse('account_on_hold', [
+          'Request failed with status 402',
+        ]) as any;
+      });
+
+      let thrownError: unknown;
+      try {
+        await model.doGenerate({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeInstanceOf(APICallError);
+      const message = (thrownError as APICallError).message;
+      expect(message).toBe(
+        `Request failed with status 402. ${ACCOUNT_ON_HOLD_GUIDANCE} | stderr (tail): Billing hold diagnostic line`
+      );
+      expect(message.match(/ \| stderr \(tail\):/g)).toHaveLength(1);
+      expect(getErrorMetadata(thrownError)?.stderr).toBe('Billing hold diagnostic line\n');
+      expect(getErrorMetadata(thrownError)?.errorKind).toBe('account_on_hold');
+      expect(isAccountStateError(thrownError)).toBe(true);
     });
 
     it('should throw error when result message has is_error flag', async () => {

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -213,8 +213,9 @@ function extractJsonObjectText(text: string): string | undefined {
 /**
  * Extracts the structured error kind attached to errors thrown from result
  * handling. SDK 0.3.x delivers API failure kinds (SDKAssistantMessageError,
- * e.g. 'overloaded', 'model_not_found', 'oauth_org_not_allowed') as structured
- * fields on assistant messages rather than in thrown error text, so
+ * e.g. 'overloaded', 'model_not_found', 'oauth_org_not_allowed',
+ * 'account_on_hold') as structured fields on assistant messages rather than
+ * in thrown error text, so
  * classification must not rely on message substrings alone.
  */
 function getStructuredErrorKind(error: unknown): string | undefined {
@@ -2259,6 +2260,33 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
     const exitCode =
       isErrorWithCode(error) && typeof error.exitCode === 'number' ? error.exitCode : undefined;
 
+    const errorCode = isErrorWithCode(error) && typeof error.code === 'string' ? error.code : '';
+
+    // SDK 0.3.x assistant error kinds: account-state problems (billing hold /
+    // billing failure). Non-retryable, and NOT an authentication error —
+    // re-authenticating cannot fix these; the account must be fixed in the
+    // Anthropic Console. Checked before the auth-substring heuristics so
+    // account-state error text mentioning "unauthorized" etc. cannot be
+    // misclassified as a credentials problem. Keys on the structured kind
+    // only — message text never selects or flips this classification.
+    if (errorKind === 'account_on_hold' || errorKind === 'billing_error') {
+      const originalMessage =
+        isErrorWithMessage(error) && error.message ? error.message : 'Account error';
+      const guidance =
+        errorKind === 'account_on_hold'
+          ? 'Your Anthropic account is on hold, so requests are being rejected. Resolve the hold in the Anthropic Console (https://console.anthropic.com), then retry — signing in again will not fix this.'
+          : 'A billing problem on your Anthropic account is blocking requests. Resolve the billing issue in the Anthropic Console (https://console.anthropic.com), then retry — signing in again will not fix this.';
+      return createAPICallError({
+        message: `${originalMessage}. ${guidance}`,
+        code: errorCode || undefined,
+        errorKind,
+        exitCode,
+        stderr,
+        promptExcerpt: messagesPrompt.substring(0, 200),
+        isRetryable: false,
+      });
+    }
+
     const isAuthError =
       errorKind === 'authentication_failed' ||
       errorKind === 'oauth_org_not_allowed' ||
@@ -2274,12 +2302,11 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
             : 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.'
         ),
         stderr,
+        errorKind,
       });
     }
 
     // Check for timeout errors
-    const errorCode = isErrorWithCode(error) && typeof error.code === 'string' ? error.code : '';
-
     if (
       errorCode === 'ETIMEDOUT' ||
       errorMessage.includes('timeout') ||
@@ -2291,6 +2318,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
         ),
         stderr,
         promptExcerpt: messagesPrompt.substring(0, 200),
+        errorKind,
         // Don't specify timeoutMs since we don't know the actual timeout value
         // It's controlled by the consumer via AbortSignal
       });
@@ -2308,6 +2336,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
             ? error.message
             : 'Anthropic API is overloaded. Please retry.',
         code: errorCode || undefined,
+        errorKind,
         exitCode,
         stderr,
         promptExcerpt: messagesPrompt.substring(0, 200),
@@ -2326,6 +2355,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
       return createAPICallError({
         message: `${originalMessage}. The requested model was not found. Verify the model id passed to the provider (e.g. 'fable', 'opus', 'sonnet', 'haiku', or a full model name) and that your account has access to it.`,
         code: errorCode || undefined,
+        errorKind,
         exitCode,
         stderr,
         promptExcerpt: messagesPrompt.substring(0, 200),
@@ -2343,6 +2373,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV4 {
     return createAPICallError({
       message: isErrorWithMessage(error) && error.message ? error.message : 'Claude Code SDK error',
       code: errorCode || undefined,
+      errorKind,
       exitCode: exitCode,
       stderr,
       promptExcerpt: messagesPrompt.substring(0, 200),

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -5,6 +5,7 @@ import {
   createTimeoutError,
   isAuthenticationError,
   isTimeoutError,
+  isAccountStateError,
   getErrorMetadata,
   stderrTail,
 } from './errors.js';
@@ -73,6 +74,18 @@ describe('Error Creation Functions', () => {
       expect(error).toBeInstanceOf(APICallError);
       expect(error.message).toBe('Minimal error');
       expect(error.requestBodyValues).toBeUndefined();
+      // Value semantics: the property may exist but reads undefined when the
+      // SDK did not deliver a structured kind.
+      expect(getErrorMetadata(error)?.errorKind).toBeUndefined();
+    });
+
+    it('round-trips errorKind into metadata', () => {
+      const error = createAPICallError({
+        message: 'Billing failure',
+        errorKind: 'billing_error',
+      });
+
+      expect(getErrorMetadata(error)?.errorKind).toBe('billing_error');
     });
 
     it('should set retryable flag', () => {
@@ -161,6 +174,36 @@ describe('Error Creation Functions', () => {
         'Authentication failed. Please ensure Claude Code SDK is properly authenticated.'
       );
     });
+
+    it('should expose errorKind metadata without stderr', () => {
+      const error = createAuthenticationError({
+        message: 'Auth failed',
+        errorKind: 'authentication_failed',
+      });
+
+      expect(error).toBeInstanceOf(LoadAPIKeyError);
+      expect(getErrorMetadata(error)?.errorKind).toBe('authentication_failed');
+      expect(getErrorMetadata(error)?.stderr).toBeUndefined();
+    });
+
+    it('should expose both stderr and errorKind metadata when both are present', () => {
+      const error = createAuthenticationError({
+        message: 'Auth failed',
+        stderr: 'Not authenticated',
+        errorKind: 'oauth_org_not_allowed',
+      });
+
+      expect(getErrorMetadata(error)?.stderr).toBe('Not authenticated');
+      expect(getErrorMetadata(error)?.errorKind).toBe('oauth_org_not_allowed');
+    });
+
+    it('should attach no data when neither stderr nor errorKind is provided', () => {
+      const error = createAuthenticationError({
+        message: 'Auth failed',
+      });
+
+      expect(getErrorMetadata(error)).toBeUndefined();
+    });
   });
 
   describe('createTimeoutError', () => {
@@ -189,6 +232,17 @@ describe('Error Creation Functions', () => {
 
       expect(error.requestBodyValues).toBeUndefined();
       expect((error.data as any).timeoutMs).toBe(60000);
+    });
+
+    it('should accept and store errorKind without changing the timeout contract', () => {
+      const error = createTimeoutError({
+        message: 'Timeout',
+        errorKind: 'unknown',
+      });
+
+      expect(getErrorMetadata(error)?.errorKind).toBe('unknown');
+      expect(getErrorMetadata(error)?.code).toBe('TIMEOUT');
+      expect(error.isRetryable).toBe(true);
     });
   });
 });
@@ -254,6 +308,63 @@ describe('Error Detection Functions', () => {
         )
       ).toBe(false);
       expect(isTimeoutError(null)).toBe(false);
+    });
+  });
+
+  describe('isAccountStateError', () => {
+    it.each(['account_on_hold', 'billing_error'])(
+      'should detect APICallError with structured kind %s',
+      (errorKind) => {
+        const error = createAPICallError({
+          message: 'Request failed with status 402',
+          errorKind,
+        });
+
+        expect(isAccountStateError(error)).toBe(true);
+      }
+    );
+
+    it('should return false for other structured kinds and missing errorKind', () => {
+      expect(
+        isAccountStateError(createAPICallError({ message: 'Overloaded', errorKind: 'overloaded' }))
+      ).toBe(false);
+      expect(
+        isAccountStateError(
+          createAPICallError({ message: 'No model', errorKind: 'model_not_found' })
+        )
+      ).toBe(false);
+      expect(isAccountStateError(createAPICallError({ message: 'Generic failure' }))).toBe(false);
+    });
+
+    it('should return false when only the message mentions an account-state token', () => {
+      const error = createAPICallError({
+        message: 'Upstream reported billing_error for this org',
+      });
+
+      expect(isAccountStateError(error)).toBe(false);
+    });
+
+    it('should return false for non-APICallError values', () => {
+      expect(isAccountStateError(new LoadAPIKeyError({ message: 'Auth failed' }))).toBe(false);
+      expect(isAccountStateError(new Error('billing_error'))).toBe(false);
+      expect(isAccountStateError(null)).toBe(false);
+      expect(isAccountStateError(undefined)).toBe(false);
+      expect(isAccountStateError({ data: { errorKind: 'billing_error' } })).toBe(false);
+    });
+
+    it('should not cross-classify with authentication or timeout checks', () => {
+      const accountStateError = createAPICallError({
+        message: 'Account on hold',
+        errorKind: 'account_on_hold',
+        exitCode: 1,
+      });
+      const authError = createAuthenticationError({ message: 'Auth failed' });
+      const timeoutError = createTimeoutError({ message: 'Timeout' });
+
+      expect(isAuthenticationError(accountStateError)).toBe(false);
+      expect(isTimeoutError(accountStateError)).toBe(false);
+      expect(isAccountStateError(authError)).toBe(false);
+      expect(isAccountStateError(timeoutError)).toBe(false);
     });
   });
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -352,6 +352,30 @@ describe('Error Detection Functions', () => {
       expect(isAccountStateError({ data: { errorKind: 'billing_error' } })).toBe(false);
     });
 
+    it.each(['account_on_hold', 'billing_error'])(
+      'should veto isAuthenticationError for kind %s even with exit code 401',
+      (errorKind) => {
+        const error = createAPICallError({
+          message: 'Request failed with status 401',
+          errorKind,
+          exitCode: 401,
+        });
+
+        expect(isAccountStateError(error)).toBe(true);
+        expect(isAuthenticationError(error)).toBe(false);
+      }
+    );
+
+    it('should leave plain exit-code-401 errors classified as authentication', () => {
+      const error = createAPICallError({
+        message: 'Unauthorized',
+        exitCode: 401,
+      });
+
+      expect(isAuthenticationError(error)).toBe(true);
+      expect(isAccountStateError(error)).toBe(false);
+    });
+
     it('should not cross-classify with authentication or timeout checks', () => {
       const accountStateError = createAPICallError({
         message: 'Account on hold',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -226,6 +226,12 @@ export function createTimeoutError({
  * Checks if an error is an authentication error.
  * Returns true for LoadAPIKeyError instances or APICallError with exit code 401.
  *
+ * Account-state errors (structured kind 'account_on_hold' or 'billing_error')
+ * always return false, even when the metadata carries exit code 401: the exit
+ * code is preserved as a diagnostic, but the structured account-state kind
+ * vetoes authentication classification — re-authenticating cannot resolve
+ * those errors. Use {@link isAccountStateError} to detect them.
+ *
  * @param error - The error to check
  * @returns True if the error is an authentication error
  *
@@ -242,6 +248,7 @@ export function createTimeoutError({
  */
 export function isAuthenticationError(error: unknown): boolean {
   if (error instanceof LoadAPIKeyError) return true;
+  if (isAccountStateError(error)) return false;
   if (error instanceof APICallError && (error.data as ClaudeCodeErrorMetadata)?.exitCode === 401)
     return true;
   return false;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -45,6 +45,22 @@ export interface ClaudeCodeErrorMetadata {
   code?: string;
 
   /**
+   * Structured assistant error kind reported by the Claude Agent SDK
+   * (`SDKAssistantMessageError`), e.g. 'account_on_hold', 'billing_error',
+   * 'overloaded', 'rate_limit', 'model_not_found', 'authentication_failed'.
+   *
+   * Holds a defined value only when the SDK delivered the kind structurally
+   * on the failing assistant message; errors classified purely from
+   * message/stderr text, process state, or exit codes read as `undefined`
+   * (the property may exist with an `undefined` value, like the other
+   * fields in this metadata envelope — check the value, not key presence).
+   * Typed as `string` (not the SDK union) so new SDK kinds flow through
+   * without a type-level break; treat unrecognized values as a generic
+   * failure.
+   */
+  errorKind?: string;
+
+  /**
    * Exit code from the Claude Code SDK process.
    * Common codes:
    * - 401: Authentication error
@@ -71,6 +87,7 @@ export interface ClaudeCodeErrorMetadata {
  * @param options - Error details and metadata
  * @param options.message - Human-readable error message
  * @param options.code - Error code from the CLI process
+ * @param options.errorKind - Structured SDK assistant error kind, when reported
  * @param options.exitCode - Exit code from the CLI
  * @param options.stderr - Standard error output
  * @param options.promptExcerpt - Excerpt of the prompt that caused the error
@@ -89,6 +106,7 @@ export interface ClaudeCodeErrorMetadata {
 export function createAPICallError({
   message,
   code,
+  errorKind,
   exitCode,
   stderr,
   promptExcerpt,
@@ -99,6 +117,7 @@ export function createAPICallError({
 }): APICallError {
   const metadata: ClaudeCodeErrorMetadata = {
     code,
+    errorKind,
     exitCode,
     stderr,
     promptExcerpt,
@@ -123,6 +142,7 @@ export function createAPICallError({
  *
  * @param options - Error configuration
  * @param options.message - Error message describing the authentication failure
+ * @param options.errorKind - Structured SDK assistant error kind, when reported
  * @returns A LoadAPIKeyError instance
  *
  * @example
@@ -135,16 +155,21 @@ export function createAPICallError({
 export function createAuthenticationError({
   message,
   stderr,
+  errorKind,
 }: {
   message: string;
   stderr?: string;
+  errorKind?: string;
 }): LoadAPIKeyError {
   const error = new LoadAPIKeyError({
     message:
       message || 'Authentication failed. Please ensure Claude Code SDK is properly authenticated.',
   });
-  if (stderr) {
-    (error as LoadAPIKeyError & { data?: ClaudeCodeErrorMetadata }).data = { stderr };
+  if (stderr || errorKind !== undefined) {
+    (error as LoadAPIKeyError & { data?: ClaudeCodeErrorMetadata }).data = {
+      ...(stderr && { stderr }),
+      ...(errorKind !== undefined && { errorKind }),
+    };
   }
   return error;
 }
@@ -156,6 +181,7 @@ export function createAuthenticationError({
  * @param options.message - Error message describing the timeout
  * @param options.promptExcerpt - Excerpt of the prompt that timed out
  * @param options.timeoutMs - Timeout duration in milliseconds
+ * @param options.errorKind - Structured SDK assistant error kind, when reported
  * @returns An APICallError instance configured as a timeout error
  *
  * @example
@@ -171,15 +197,18 @@ export function createTimeoutError({
   stderr,
   promptExcerpt,
   timeoutMs,
+  errorKind,
 }: {
   message: string;
   stderr?: string;
   promptExcerpt?: string;
   timeoutMs?: number;
+  errorKind?: string;
 }): APICallError {
   // Store timeoutMs in metadata for potential use by error handlers
   const metadata: ClaudeCodeErrorMetadata = {
     code: 'TIMEOUT',
+    errorKind,
     stderr,
     promptExcerpt,
   };
@@ -240,6 +269,37 @@ export function isTimeoutError(error: unknown): boolean {
   if (error instanceof APICallError && (error.data as ClaudeCodeErrorMetadata)?.code === 'TIMEOUT')
     return true;
   return false;
+}
+
+/**
+ * Checks if an error is an account-state error (billing hold or billing
+ * failure on the Anthropic account). These are not credential problems:
+ * re-authenticating will not resolve them — the account must be fixed in
+ * the Anthropic Console (https://console.anthropic.com).
+ *
+ * Returns true exactly when the provider classified the error as
+ * account-state, which happens if and only if the metadata carries the
+ * structured SDK error kind 'account_on_hold' or 'billing_error' on an
+ * APICallError. Message text and stderr are intentionally not inspected.
+ *
+ * @param error - The error to check
+ * @returns True if the error is an account-state error
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await model.generate(...);
+ * } catch (error) {
+ *   if (isAccountStateError(error)) {
+ *     console.log('Resolve the billing issue or hold in the Anthropic Console');
+ *   }
+ * }
+ * ```
+ */
+export function isAccountStateError(error: unknown): boolean {
+  if (!(error instanceof APICallError)) return false;
+  const kind = (error.data as ClaudeCodeErrorMetadata | undefined)?.errorKind;
+  return kind === 'account_on_hold' || kind === 'billing_error';
 }
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,8 @@ import * as indexExports from './index.js';
 import * as providerExports from './claude-code-provider.js';
 import * as errorExports from './errors.js';
 import type {
+  ClaudeCodeErrorMetadata,
+  SDKAssistantMessageError,
   ClaudeCodeSettings,
   ClaudeCodeHookEvent,
   ClaudeCodeMcpStatusEvent,
@@ -63,6 +65,15 @@ type HookSurfaceExportedTypes = [
 
 const hookSurfaceExportedTypesCompileCheck: HookSurfaceExportedTypes | null = null;
 
+// Compile-time check that the re-exported ClaudeCodeErrorMetadata keeps
+// `errorKind` open (`string`, not the SDK union) so future SDK kinds flow
+// through without a type-level break, and that the SDK's current known-value
+// union is importable from the package entry point.
+const openErrorKindCompileCheck: ClaudeCodeErrorMetadata = {
+  errorKind: 'future_sdk_kind',
+};
+const sdkAssistantMessageErrorCompileCheck: SDKAssistantMessageError | null = null;
+
 describe('index exports', () => {
   it('should export all expected functions and types', () => {
     // Provider exports
@@ -83,6 +94,8 @@ describe('index exports', () => {
     expect(typeof indexExports.isAuthenticationError).toBe('function');
     expect(indexExports.isTimeoutError).toBeDefined();
     expect(typeof indexExports.isTimeoutError).toBe('function');
+    expect(indexExports.isAccountStateError).toBeDefined();
+    expect(typeof indexExports.isAccountStateError).toBe('function');
     expect(indexExports.getErrorMetadata).toBeDefined();
     expect(typeof indexExports.getErrorMetadata).toBe('function');
     expect(indexExports.createAPICallError).toBeDefined();
@@ -145,6 +158,7 @@ describe('index exports', () => {
     expect(indexExports.claudeCode).toBe(providerExports.claudeCode);
     expect(indexExports.isAuthenticationError).toBe(errorExports.isAuthenticationError);
     expect(indexExports.isTimeoutError).toBe(errorExports.isTimeoutError);
+    expect(indexExports.isAccountStateError).toBe(errorExports.isAccountStateError);
   });
 
   it('should export Agent SDK callback and controller public types', () => {
@@ -153,5 +167,10 @@ describe('index exports', () => {
 
   it('should export the SDK 0.3.251 hook surface types', () => {
     expect(hookSurfaceExportedTypesCompileCheck).toBeNull();
+  });
+
+  it('should keep errorKind open and re-export SDKAssistantMessageError', () => {
+    expect(openErrorKindCompileCheck.errorKind).toBe('future_sdk_kind');
+    expect(sdkAssistantMessageErrorCompileCheck).toBeNull();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,8 @@ export type {
   ThinkingAdaptive,
   ThinkingEnabled,
   ThinkingDisabled,
+  // Structured assistant error kinds (values that can appear in error metadata `errorKind`)
+  SDKAssistantMessageError,
 } from '@anthropic-ai/claude-agent-sdk';
 
 /**
@@ -300,6 +302,7 @@ export type {
  *
  * @see {@link isAuthenticationError} to check for authentication failures
  * @see {@link isTimeoutError} to check for timeout errors
+ * @see {@link isAccountStateError} to check for account-state (billing/hold) failures
  * @see {@link getErrorMetadata} to extract error metadata
  * @see {@link createAPICallError} to create general API errors
  * @see {@link createAuthenticationError} to create authentication errors
@@ -308,6 +311,7 @@ export type {
 export {
   isAuthenticationError,
   isTimeoutError,
+  isAccountStateError,
   getErrorMetadata,
   createAPICallError,
   createAuthenticationError,


### PR DESCRIPTION
Closes #155. Follow-up from #153/#154, folded into the still-unpublished v4.2.0 release (npm latest is 4.1.1; no v4.2.0 tag exists), so the version quad stays at 4.2.0 and the changelog entries are merged under `[4.2.0]`.

## What changed

- **`errorKind` on `ClaudeCodeErrorMetadata`** — the structured SDK assistant error kind (`SDKAssistantMessageError`) is preserved on every mapped error path (auth `LoadAPIKeyError`s, timeouts, overloaded/rate_limit, model_not_found, account-state, generic fallback). Set only when the SDK delivered the kind structurally; heuristic (message/stderr/exit-code) classifications never fabricate one. Typed as open `string` so future SDK kinds flow through without a type-level break.
- **Actionable `account_on_hold` / `billing_error` mapping** — structured-kind-only branch placed **before** the auth-substring heuristics, producing non-retryable `APICallError`s with Anthropic Console guidance. Explicitly **not** `LoadAPIKeyError`: account-state problems, not credential problems, and account-state error text mentioning "unauthorized" can no longer be misrouted to re-authentication.
- **`isAccountStateError()` helper** — structural check (APICallError + `account_on_hold`/`billing_error` kind); never inspects message text. `SDKAssistantMessageError` re-exported for consumers narrowing `errorKind`.
- **Tests** — 52 new (1028 total): factory round-trips, helper truth tables, generate+stream account-state mapping, auth-precedence, structured-kind-conflict both directions, unknown-kind fall-through, stderr-tail coexistence, entry-point export checks.
- **Docs** — README error-diagnostics section extended with the `errorKind` contract and an `isAccountStateError`-before-auth example. Historical `docs/ai-sdk-v4|v5` guides intentionally untouched (marked legacy 1.x–2.x).

## Process

Architected and reviewed via a cross-model flowition workflow: claude-fable-5 and gpt-5.6-sol designed independently and converged on a co-signed spec (one objection round); fable-5 implemented; gpt-5.6-sol adversarially reviewed (ran the gates itself) and passed it round 1. Remaining doc minors applied manually.

`npm run lint`, `npm test` (1028/1028), and `npm run build` all pass.