### PR TITLE
fix(ci): raise Claude Code Review --max-turns to 50

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -95,4 +95,4 @@ jobs:
           # (currently Opus 5), so model retirements never break this job.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 20
+            --max-turns 50


### PR DESCRIPTION
First real run of the review workflow (post token fix) failed with error_max_turns: 21 turns used, 6 permission denials, review incomplete. 20 turns is too tight for a comprehensive tracked review with inline comments. Raises the cap to 50.

Note: the Claude review will skip on this PR itself by design (workflow file differs from main).