### PR TITLE
fix(ci): remove --max-turns caps, add job timeout-minutes backstops

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   review-with-tracking:
     runs-on: ubuntu-latest
+    # Overrun backstop (instead of --max-turns; see note on claude_args below).
+    timeout-minutes: 30
     # The secrets context is not allowed in a job-level `if` — gating on
     # secrets.CLAUDE_CODE_OAUTH_TOKEN made the whole workflow file invalid, so
     # GitHub reported a 0-second "workflow file issue" failure on every push.
@@ -93,6 +95,8 @@ jobs:
           # mcp__github_inline_comment tool is what enables inline review comments.
           # No --model: defer to the Claude Code default for the account
           # (currently Opus 5), so model retirements never break this job.
+          # No --max-turns: a cap fails the run after spending tokens but before
+          # posting the review (a normal review of this repo already needs 20+
+          # turns). The job-level timeout-minutes above is the overrun backstop.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 50

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Overrun backstop (instead of --max-turns; see note below).
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -54,14 +56,15 @@ jobs:
           # Optional: Trigger when a specific label is added
           # label_trigger: "claude"
 
-          # Configure Claude's behavior with CLI arguments
           # Note: --allowedTools is intentionally omitted to preserve access to all
           # default tools (Read, Edit, Write, Glob, Grep, etc.). Specifying it acts
           # as a full allowlist and would block core file tools.
           # No --model: defer to the Claude Code default for the account
           # (currently Opus 5), so model retirements never break this job.
-          claude_args: |
-            --max-turns 40
+          # No --max-turns: the upstream examples ship without a turn cap, and a
+          # cap fails the run after spending tokens but before delivering results
+          # (turns needed vary widely by task). The job-level timeout-minutes
+          # above is the overrun backstop instead.
 
           # Optional: Advanced settings configuration
           # settings: |


### PR DESCRIPTION
Removes --max-turns from claude-code-review.yml (50) and claude.yml (40); adds timeout-minutes: 30/60 respectively.

Rationale: the first real review run failed with error_max_turns at 20 turns on a normal PR — a turn cap discards work after the spend. Upstream anthropics/claude-code-action examples ship with --max-turns commented out (no cap); the action has no built-in timeout, so job-level timeout-minutes is the proper overrun backstop.

Note: the Claude review will skip on this PR itself by design (workflow file differs from main).